### PR TITLE
fix goal task session lifecycle

### DIFF
--- a/cmd/podiomd/manage_tools.go
+++ b/cmd/podiomd/manage_tools.go
@@ -187,7 +187,7 @@ func taskTools(c *manageClient) []mcpTool {
 		{
 			Name:        "podiom_create_task",
 			APIRoutes:   []string{"/api/tasks"},
-			Description: "Create a roadmap item (task). plan_required=true puts the agent in plan mode for this task. Leave pickup_at empty for an on-demand task, or set an RFC3339 timestamp to schedule automatic pickup.",
+			Description: "Create a roadmap item (task). plan_required=true puts the agent in plan mode for this task. Leave pickup_at empty for an on-demand task, or set an RFC3339 timestamp to schedule automatic pickup. To move work to in_progress, call podiom_start_task instead of setting status directly.",
 			InputSchema: objectSchema([]string{"title"}, map[string]any{
 				"project_id":     strProp("Project id this task belongs to."),
 				"title":          strProp("Short task title."),
@@ -197,10 +197,10 @@ func taskTools(c *manageClient) []mcpTool {
 				"profile":        strProp("Profile override. Omit for agent default."),
 				"model":          strProp("Model override. Required with any run target override."),
 				"effort":         strProp("Effort override. Required with any run target override."),
-				"status":         strProp("Initial status (defaults to backlog): backlog, in_progress, review, done."),
+				"status":         strProp("Initial status (defaults to backlog): backlog, review, done. in_progress is only valid after starting a task."),
 				"plan_required":  boolProp("Require plan mode for this task."),
 				"pickup_at":      strProp("RFC3339 time to auto-start the task; empty = on-demand."),
-				"goal_id":        strProp("Goal id when this task is part of a goal's plan. REQUIRED for tasks you create for a goal: it links the task's runs to the goal timeline and runs them autonomously (yolo)."),
+				"goal_id":        strProp("Goal id when this task is part of a goal's plan. REQUIRED for tasks you create for a goal: it links started task runs to the goal timeline and runs them autonomously (yolo)."),
 			}),
 			Handler: func(ctx context.Context, args json.RawMessage) (string, error) {
 				m, err := argMap(args)
@@ -217,7 +217,7 @@ func taskTools(c *manageClient) []mcpTool {
 		{
 			Name:        "podiom_update_task",
 			APIRoutes:   []string{"/api/tasks/"},
-			Description: "Update fields of an existing roadmap item (task). Only the fields you pass are changed.",
+			Description: "Update fields of an existing roadmap item (task). Only the fields you pass are changed. To move backlog work to in_progress, call podiom_start_task instead of setting status directly.",
 			InputSchema: objectSchema([]string{"id"}, map[string]any{
 				"id":             strProp("Task id."),
 				"project_id":     strProp("New project id."),
@@ -228,10 +228,10 @@ func taskTools(c *manageClient) []mcpTool {
 				"profile":        strProp("Profile override. Empty string returns to agent default."),
 				"model":          strProp("Model override. Empty string returns to agent default only when the whole target is empty."),
 				"effort":         strProp("Effort override. Empty string returns to agent default only when the whole target is empty."),
-				"status":         strProp("New status: backlog, in_progress, review, done."),
+				"status":         strProp("New status: backlog, review, done. in_progress is only valid for tasks that already have a started session."),
 				"plan_required":  boolProp("Toggle plan mode."),
 				"pickup_at":      strProp("RFC3339 scheduled pickup time; empty string clears it."),
-				"goal_id":        strProp("Goal id to link this task to a goal (its runs become autonomous and audited on the goal timeline); empty string unlinks it."),
+				"goal_id":        strProp("Goal id to link this task to a goal (started runs become autonomous and audited on the goal timeline); empty string unlinks it."),
 			}),
 			Handler: func(ctx context.Context, args json.RawMessage) (string, error) {
 				m, err := argMap(args)
@@ -270,8 +270,11 @@ func taskTools(c *manageClient) []mcpTool {
 		{
 			Name:        "podiom_start_task",
 			APIRoutes:   []string{"/api/tasks/"},
-			Description: "Start a roadmap item (task) now: creates a session for its assigned agent and moves it to in_progress.",
-			InputSchema: objectSchema([]string{"id"}, map[string]any{"id": strProp("Task id.")}),
+			Description: "Start a roadmap item (task) now: creates a session for its assigned agent, moves it to in_progress, and by default runs the first turn unattended. Goal-linked tasks run yolo.",
+			InputSchema: objectSchema([]string{"id"}, map[string]any{
+				"id":         strProp("Task id."),
+				"unattended": boolProp("Run the first turn server-side. Defaults to true for agent/tool starts."),
+			}),
 			Handler: func(ctx context.Context, args json.RawMessage) (string, error) {
 				m, err := argMap(args)
 				if err != nil {
@@ -280,7 +283,11 @@ func taskTools(c *manageClient) []mcpTool {
 				if err := requireField(m, "id"); err != nil {
 					return "", err
 				}
-				return c.post(ctx, "/api/tasks/"+url.PathEscape(argString(m, "id"))+"/start", nil)
+				unattended := true
+				if _, ok := m["unattended"]; ok {
+					unattended = argBool(m, "unattended")
+				}
+				return c.post(ctx, "/api/tasks/"+url.PathEscape(argString(m, "id"))+"/start", map[string]bool{"unattended": unattended})
 			},
 		},
 	}

--- a/cmd/podiomd/manage_tools_test.go
+++ b/cmd/podiomd/manage_tools_test.go
@@ -178,6 +178,23 @@ func TestUpdateTaskPatchOmitsAbsentKeys(t *testing.T) {
 	}
 }
 
+func TestStartTaskPostsUnattendedByDefault(t *testing.T) {
+	rec, c := newRecordingServer(t)
+	if _, err := callTool(t, c, "podiom_start_task", map[string]any{"id": "t1"}); err != nil {
+		t.Fatalf("start task: %v", err)
+	}
+	if rec.method != http.MethodPost || rec.path != "/api/tasks/t1/start" {
+		t.Fatalf("got %s %s", rec.method, rec.path)
+	}
+	var unattended bool
+	if err := json.Unmarshal(rec.body["unattended"], &unattended); err != nil {
+		t.Fatalf("decode unattended: %v body=%v", err, rec.body)
+	}
+	if !unattended {
+		t.Fatalf("start task should default unattended, body=%v", rec.body)
+	}
+}
+
 func TestDeleteTaskRequiresConfirmBeforeHTTP(t *testing.T) {
 	rec, c := newRecordingServer(t)
 	_, err := callTool(t, c, "podiom_delete_task", map[string]any{"id": "t1"})

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -75,8 +75,8 @@ detail triggers one immediately.
 
 A goal exists to reach an outcome **without** you in the loop, so the whole goal
 chain runs with full autonomous access (yolo): the lead agent's planning and
-review sessions, **and every roadmap task and schedule the goal creates**,
-execute with no per-action approval prompts (Claude `--permission-mode
+review sessions, **and every started roadmap task and schedule the goal
+creates**, execute with no per-action approval prompts (Claude `--permission-mode
 bypassPermissions`; Codex `approvalPolicy: never` + `sandbox:
 danger-full-access`). The agent can run shell commands, edit files, install
 tools, and reach the network directly.
@@ -84,8 +84,9 @@ tools, and reach the network directly.
 This is deliberate and clearly disclosed: the goal-creation form shows a
 full-access warning before you create the goal, and the goal detail view carries
 a persistent **autonomous · full access** badge. Tasks a goal creates carry its
-`goal_id` (their runs are forced yolo even if the task was plan-gated), and
-schedules a goal creates are written with `run_permission: yolo`.
+`goal_id` (their runs are forced yolo even if the task was plan-gated), and the
+lead starts task work with `podiom_start_task` when it should begin. Schedules a
+goal creates are written with `run_permission: yolo`.
 
 The counterweight is a complete audit trail: every tool call the goal chain
 makes is recorded on the goal timeline (see below).
@@ -172,8 +173,10 @@ yolo, audited on the goal timeline).
 - No spend/token budgets or caps on how many tasks/schedules a goal may spawn —
   the audit trail is the control.
 - Tasks and schedules the agent creates for the goal carry its `goal_id`, so
-  their runs are autonomous (yolo) and recorded on the goal timeline. Work the
-  agent creates without a `goal_id` is not linked and runs under the normal
-  (stricter) unattended policy.
+  their started runs are autonomous (yolo) and recorded on the goal timeline.
+  Creating a task does not start it; the lead starts task work with
+  `podiom_start_task` when execution should begin. Work the agent creates
+  without a `goal_id` is not linked and runs under the normal (stricter)
+  unattended policy.
 - Reviews only fire while `podiomd` is running; an overdue review fires on the
   next scheduler tick after restart.

--- a/internal/core/goal_audit_test.go
+++ b/internal/core/goal_audit_test.go
@@ -211,6 +211,13 @@ func TestGoalLinkedTaskRunsYolo(t *testing.T) {
 	if req.Relay != nil {
 		t.Fatalf("yolo goal-linked task run must not attach a permission relay")
 	}
+	history, err := c.History(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if len(history) != 2 || history[0].Role != store.RoleUser || history[1].Content != "worked" {
+		t.Fatalf("unexpected goal-linked task history: %+v", history)
+	}
 }
 
 func TestGoalLinkedScheduleForcesYolo(t *testing.T) {

--- a/internal/core/goal_sessions.go
+++ b/internal/core/goal_sessions.go
@@ -29,7 +29,7 @@ exactly what you did while they were away.
 ## Your job right now (planning session)
 
 1. Decompose the goal into concrete work:
-   - Create roadmap tasks with podiom_create_task (assign other agents where sensible; you stay accountable). Pass goal_id (this goal's ID, above) so the task's runs are linked to this goal, run autonomously, and are audited on this timeline.
+   - Create roadmap tasks with podiom_create_task (assign other agents where sensible; you stay accountable). Pass goal_id (this goal's ID, above) so any started task runs are linked to this goal, run autonomously, and are audited on this timeline. Leave new tasks in backlog unless work should start immediately; when it should start, call podiom_start_task rather than setting status to in_progress.
    - Create recurring schedules with podiom_create_schedule for work that must repeat, passing goal_id so they run as part of this goal's autonomous chain.
 2. Do quick setup and investigation directly (install a CLI tool, read the repo, run a probe command) — but push the substantial and recurring work into the tasks and schedules above so it is tracked and survives this session.
 3. Consider the user's feedback above as strategic guidance when shaping the plan, unless it conflicts with the goal definition or success criteria.
@@ -91,7 +91,7 @@ tool-call entries to stay readable; the full record is on the goal page.)
 
 ## Your job right now (review session)
 
-1. Assess progress against the success criteria. Check the state of the tasks and schedules you created (podiom_list_tasks, podiom_list_schedules) and adjust them where the plan has drifted.
+1. Assess progress against the success criteria. Check the state of the tasks and schedules you created (podiom_list_tasks, podiom_list_schedules) and adjust them where the plan has drifted. Start backlog tasks with podiom_start_task when autonomous work should begin; do not move a task to in_progress by editing status directly.
 2. Consider the user's recent feedback above as strategic guidance when adjusting tasks, schedules, or next steps, unless it conflicts with explicit success criteria or status.
 3. Record a progress entry with podiom_record_goal_progress: what moved since the last review, with evidence. Update metric values there when they changed.
 4. Take direct corrective action when it is quick and unblocks progress (run a command, fix a file, unstick a task); push larger or recurring work into tasks and schedules (with goal_id) so it is tracked.

--- a/internal/core/projects.go
+++ b/internal/core/projects.go
@@ -317,6 +317,9 @@ func (c *Core) CreateTask(ctx context.Context, task store.Task) (store.Task, err
 	if strings.TrimSpace(task.Title) == "" {
 		return store.Task{}, fmt.Errorf("task title is required")
 	}
+	if task.Status == store.TaskInProgress {
+		return store.Task{}, fmt.Errorf("task cannot be created in_progress; start the task to create a session")
+	}
 	if task.GoalID != "" {
 		if _, err := c.store.GetGoal(ctx, task.GoalID); err != nil {
 			return store.Task{}, fmt.Errorf("goal %q: %w", task.GoalID, err)
@@ -357,9 +360,14 @@ func (c *Core) UpdateTask(ctx context.Context, task store.Task) (store.Task, err
 	if err != nil {
 		return store.Task{}, err
 	}
-	if hasSession, err := c.taskHasSession(ctx, task.ID); err != nil {
+	hasSession, err := c.taskHasSession(ctx, task.ID)
+	if err != nil {
 		return store.Task{}, err
-	} else if hasSession && taskChangesLockedFields(existing, task) {
+	}
+	if task.Status == store.TaskInProgress && !hasSession {
+		return store.Task{}, fmt.Errorf("task %q cannot be marked in_progress without starting a session", task.ID)
+	}
+	if hasSession && taskChangesLockedFields(existing, task) {
 		return store.Task{}, fmt.Errorf("task %q already has a session; only status can be changed", task.ID)
 	}
 	if err := validateTaskProvider(task); err != nil {

--- a/internal/core/projects_test.go
+++ b/internal/core/projects_test.go
@@ -223,6 +223,44 @@ func TestCreateTaskRejectsIncompleteRunTarget(t *testing.T) {
 	}
 }
 
+func TestGoalLinkedTaskCannotBeMarkedInProgressWithoutSession(t *testing.T) {
+	ctx := context.Background()
+	c, _, cleanup := newScheduledTestCore(t)
+	defer cleanup()
+
+	if _, err := c.CreateAgent(ctx, CreateAgentRequest{Name: "worker", Provider: config.ProviderClaude}); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	goal, err := c.CreateGoal(ctx, store.Goal{Title: "Ship it", LeadAgent: "worker"})
+	if err != nil {
+		t.Fatalf("create goal: %v", err)
+	}
+	if _, err := c.CreateTask(ctx, store.Task{
+		Title:         "Direct start",
+		AssignedAgent: "worker",
+		GoalID:        goal.ID,
+		Status:        store.TaskInProgress,
+	}); err == nil {
+		t.Fatal("expected direct in_progress create to fail")
+	}
+
+	task, err := c.CreateTask(ctx, store.Task{
+		Title:         "Move directly",
+		AssignedAgent: "worker",
+		GoalID:        goal.ID,
+	})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	task.Status = store.TaskInProgress
+	if _, err := c.UpdateTask(ctx, task); err == nil {
+		t.Fatal("expected direct in_progress update without session to fail")
+	}
+	if _, ok, err := c.TaskSession(ctx, task.ID); err != nil || ok {
+		t.Fatalf("task should still have no session: ok=%v err=%v", ok, err)
+	}
+}
+
 func TestCreateSessionStoresProjectAndRejectsUnknownProject(t *testing.T) {
 	ctx := context.Background()
 	c, _, cleanup := newScheduledTestCore(t)

--- a/internal/server/projects.go
+++ b/internal/server/projects.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -388,6 +390,10 @@ type taskArchiveDoneRequest struct {
 	ProjectID string `json:"project_id,omitempty"`
 }
 
+type taskStartRequest struct {
+	Unattended bool `json:"unattended"`
+}
+
 func (s *Server) handleTasks(w http.ResponseWriter, r *http.Request) {
 	if s.core == nil {
 		http.Error(w, "core unavailable", http.StatusServiceUnavailable)
@@ -484,7 +490,12 @@ func (s *Server) handleTask(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		session, err := s.core.StartTask(r.Context(), core.StartTaskRequest{TaskID: id})
+		var req taskStartRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		session, err := s.core.StartTask(r.Context(), core.StartTaskRequest{TaskID: id, Unattended: req.Unattended})
 		if err == nil {
 			s.log.Info("task start requested", "event", "task", "task", id, "session", session.ID, "agent", session.AgentName, "project", session.ProjectID)
 		}

--- a/internal/server/projects_test.go
+++ b/internal/server/projects_test.go
@@ -72,6 +72,38 @@ func TestTaskDescribeEndpointsReturnBody(t *testing.T) {
 	}
 }
 
+func TestTaskStartEndpointRunsUnattendedWhenRequested(t *testing.T) {
+	ctx := context.Background()
+	_, srv, cleanup := newAgentAPITestServer(t)
+	defer cleanup()
+
+	if _, err := srv.core.CreateAgent(ctx, core.CreateAgentRequest{Name: "worker", Provider: config.ProviderClaude}); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	task, err := srv.core.CreateTask(ctx, store.Task{Title: "Run it", AssignedAgent: "worker"})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/"+task.ID+"/start", bytes.NewBufferString(`{"unattended":true}`))
+	rr := httptest.NewRecorder()
+	srv.handleTask(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var sess store.Session
+	if err := json.NewDecoder(rr.Body).Decode(&sess); err != nil {
+		t.Fatalf("decode session: %v", err)
+	}
+	history, err := srv.core.History(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if len(history) != 2 || history[0].Role != store.RoleUser {
+		t.Fatalf("unexpected started history: %+v", history)
+	}
+}
+
 func TestProjectInstructionsEndpointReadsAndWrites(t *testing.T) {
 	ctx := context.Background()
 	_, srv, cleanup := newAgentAPITestServer(t)


### PR DESCRIPTION
## Summary
- prevent roadmap tasks from being created or patched directly into in_progress without a linked session
- make task starts accept an unattended flag and have MCP task starts run unattended by default
- update goal-agent guidance and docs to use podiom_start_task for autonomous task execution

## Validation
- PATH=/data/podiom/projects/podiom/.tools/go1.26.5/bin:$PATH go test ./internal/core ./internal/server ./cmd/podiomd
- git diff --check

## Root Cause
Goal review agents could create or update goal-linked tasks with status in_progress through generic task APIs. That state did not guarantee a roadmap-origin session had actually been started or that the initial turn had been persisted, so opening the task chat could show an empty history.