### PR TITLE
Document skills CLI commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -204,6 +204,28 @@ prints the gateway-token location. On supported local desktops it copies the
 token to the clipboard; otherwise it prints clear manual-copy instructions. The
 token value is printed only to your terminal, never to daemon or add-on logs.
 
+### `podiom skills`
+
+Browse the reusable `SKILL.md` capability folders available to agents. Podiom
+discovers skills under `~/.agents/skills`, `~/.claude/skills`, and
+`~/.codex/skills`, then presents one deduplicated catalogue.
+
+```
+podiom skills list
+podiom skills list --source codex
+podiom skills show hello-podiom
+podiom skills paths
+podiom skills scan
+podiom skills relink
+```
+
+| Command | Description |
+| --- | --- |
+| `list [--source agents\|claude\|codex]` | List skills with their source badges and descriptions. |
+| `show <name>` | Print a skill's `SKILL.md`, source paths, and any cross-source conflict. |
+| `paths` | Print the three skill roots and resolved union topology. |
+| `scan` / `relink` | Rebuild the shared `~/.agents/skills` union links without overwriting real folders. |
+
 ### `podiom agents list`
 
 List durable agents known to the daemon.


### PR DESCRIPTION
## Summary

- add a `podiom skills` section to the CLI reference
- document list, show, paths, scan, and relink usage
- explain skill discovery roots and the shared union

## Verification

- `go test ./...`
- `git diff --check`

Closes #4
