### PR TITLE
docs: link overlooked reference pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ All runtime state lives under `$PODIOM_HOME` (default `~/.podiom/`).
 - [Requirements](docs/requirements.md) — the authoritative spec (v1.6).
 - [CLI reference](docs/cli.md)
 - [Configuration](docs/configuration.md)
+- [Agents](docs/agents.md) — durable, named colleagues and their stored defaults
+- [Git](docs/git.md) — how projects carry source control
+- [Sessions](docs/sessions.md) — the durable conversation unit
+- [SOUL.md generation](docs/soul-generation.md) — how agent identity files are generated
 - [Scheduling](docs/scheduling.md)
 - [Projects & Roadmap](docs/projects.md)
 - [Goals](docs/goals.md) — hand an outcome to an agent; it plans, reviews, and reports back


### PR DESCRIPTION
## Summary
Makes four existing reference pages discoverable from the README documentation index.

## Changes
- add links for Agents, Git, Sessions, and SOUL.md generation
- use descriptions verified against each linked page

## Related issue
Fixes #9

## Validation
- `git diff --check`
- verified all four linked files exist and their README links are present
- `go test ./...` and `go vet ./...` could not run because Go is not installed in this runner (`go: command not found`)

## Notes
This focused documentation change was prepared with automated assistance and reviewed against the repository documentation and contribution guidelines.