### PR TITLE
feat: add `podiom usage tokens` command

### DIFF
--- a/cmd/podiom/usage.go
+++ b/cmd/podiom/usage.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"text/tabwriter"
 	"time"
 
+	"github.com/Podiom/Podiom/internal/store"
 	"github.com/Podiom/Podiom/internal/usage"
 	"github.com/spf13/cobra"
 )
@@ -39,6 +41,7 @@ func newUsageCmd(addr *string) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "print machine-readable JSON")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "force a live re-fetch instead of cached data")
+	cmd.AddCommand(newUsageTokensCmd(addr))
 	return cmd
 }
 
@@ -114,4 +117,197 @@ func formatCredits(c *usage.Credits) string {
 		return fmt.Sprintf("credits: %.2f/%.2f %s used", c.UsedCredits, c.MonthlyLimit, c.Currency)
 	}
 	return fmt.Sprintf("credits: %.2f balance", c.Balance)
+}
+
+func newUsageTokensCmd(addr *string) *cobra.Command {
+	var agent string
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "tokens",
+		Short: "Show token usage across sessions",
+		Long:  "Aggregates and displays token usage (input, output, cache) from all sessions, optionally filtered by agent.",
+		Example: "  podiom usage tokens\n" +
+			"  podiom usage tokens --agent jared\n" +
+			"  podiom usage tokens --json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := daemonClient(*addr)
+			if err != nil {
+				return err
+			}
+			sessions, err := c.ListSessions(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			// Filter by agent if specified
+			if agent != "" {
+				var filtered []store.Session
+				for _, s := range sessions {
+					if s.AgentName == agent {
+						filtered = append(filtered, s)
+					}
+				}
+				sessions = filtered
+			}
+
+			// Aggregate by agent
+			stats := aggregateTokenUsage(sessions)
+
+			if jsonOut {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(stats)
+			}
+
+			if agent != "" && len(stats.ByAgent) == 1 {
+				// Single agent detail view
+				formatTokensDetail(os.Stdout, stats.ByAgent[0], aggregateByModel(sessions))
+			} else {
+				// Summary table view
+				formatTokensTable(os.Stdout, stats)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&agent, "agent", "", "filter by agent name")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "output as JSON")
+	return cmd
+}
+
+// TokenStats holds aggregated token usage.
+type TokenStats struct {
+	TotalSessions int              `json:"total_sessions"`
+	Total         store.SessionUsage `json:"total"`
+	ByAgent       []AgentTokenStats  `json:"by_agent"`
+}
+
+// AgentTokenStats holds per-agent token usage.
+type AgentTokenStats struct {
+	Agent    string             `json:"agent"`
+	Sessions int                `json:"sessions"`
+	Usage    store.SessionUsage `json:"usage"`
+}
+
+// ModelTokenStats holds per-model token usage.
+type ModelTokenStats struct {
+	Model string `json:"model"`
+	Total int64  `json:"total"`
+}
+
+func aggregateTokenUsage(sessions []store.Session) TokenStats {
+	byAgent := make(map[string]*AgentTokenStats)
+	var total store.SessionUsage
+
+	for _, s := range sessions {
+		total = total.Add(s.Usage)
+
+		agent := s.AgentName
+		if agent == "" {
+			agent = "(none)"
+		}
+		if _, ok := byAgent[agent]; !ok {
+			byAgent[agent] = &AgentTokenStats{Agent: agent}
+		}
+		byAgent[agent].Sessions++
+		byAgent[agent].Usage = byAgent[agent].Usage.Add(s.Usage)
+	}
+
+	// Convert map to sorted slice
+	var agents []AgentTokenStats
+	for _, a := range byAgent {
+		agents = append(agents, *a)
+	}
+	sort.Slice(agents, func(i, j int) bool {
+		return agents[i].Usage.Total() > agents[j].Usage.Total()
+	})
+
+	return TokenStats{
+		TotalSessions: len(sessions),
+		Total:         total,
+		ByAgent:       agents,
+	}
+}
+
+func aggregateByModel(sessions []store.Session) []ModelTokenStats {
+	byModel := make(map[string]int64)
+	for _, s := range sessions {
+		model := s.Model
+		if model == "" {
+			model = "(default)"
+		}
+		byModel[model] += s.Usage.Total()
+	}
+
+	var models []ModelTokenStats
+	for m, t := range byModel {
+		models = append(models, ModelTokenStats{Model: m, Total: t})
+	}
+	sort.Slice(models, func(i, j int) bool {
+		return models[i].Total > models[j].Total
+	})
+	return models
+}
+
+func formatTokensTable(w io.Writer, stats TokenStats) {
+	if len(stats.ByAgent) == 0 {
+		fmt.Fprintln(w, "no token usage data")
+		return
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "AGENT\tSESSIONS\tINPUT\tOUTPUT\tCACHE_R\tCACHE_W\tTOTAL")
+	for _, a := range stats.ByAgent {
+		fmt.Fprintf(tw, "%s\t%d\t%s\t%s\t%s\t%s\t%s\n",
+			a.Agent,
+			a.Sessions,
+			formatTokenCount(a.Usage.InputTokens),
+			formatTokenCount(a.Usage.OutputTokens),
+			formatTokenCount(a.Usage.CacheReadTokens),
+			formatTokenCount(a.Usage.CacheWriteTokens),
+			formatTokenCount(a.Usage.Total()),
+		)
+	}
+	fmt.Fprintln(tw, "────────\t────────\t────────\t────────\t────────\t────────\t────────")
+	fmt.Fprintf(tw, "TOTAL\t%d\t%s\t%s\t%s\t%s\t%s\n",
+		stats.TotalSessions,
+		formatTokenCount(stats.Total.InputTokens),
+		formatTokenCount(stats.Total.OutputTokens),
+		formatTokenCount(stats.Total.CacheReadTokens),
+		formatTokenCount(stats.Total.CacheWriteTokens),
+		formatTokenCount(stats.Total.Total()),
+	)
+	tw.Flush()
+}
+
+func formatTokensDetail(w io.Writer, agent AgentTokenStats, models []ModelTokenStats) {
+	fmt.Fprintf(w, "Agent: %s\n", agent.Agent)
+	fmt.Fprintf(w, "Sessions: %d\n\n", agent.Sessions)
+
+	fmt.Fprintln(w, "Token breakdown:")
+	fmt.Fprintf(w, "  Input:       %s\n", formatTokenCount(agent.Usage.InputTokens))
+	fmt.Fprintf(w, "  Output:      %s\n", formatTokenCount(agent.Usage.OutputTokens))
+	fmt.Fprintf(w, "  Cache read:  %s\n", formatTokenCount(agent.Usage.CacheReadTokens))
+	fmt.Fprintf(w, "  Cache write: %s\n", formatTokenCount(agent.Usage.CacheWriteTokens))
+	fmt.Fprintln(w, "  ─────────────────────")
+	fmt.Fprintf(w, "  Total:       %s\n", formatTokenCount(agent.Usage.Total()))
+
+	if len(models) > 0 {
+		fmt.Fprintln(w, "\nBy model:")
+		for _, m := range models {
+			fmt.Fprintf(w, "  %s: %s\n", m.Model, formatTokenCount(m.Total))
+		}
+	}
+}
+
+func formatTokenCount(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	if n >= 1_000_000 {
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	}
+	if n >= 1_000 {
+		return fmt.Sprintf("%.1fK", float64(n)/1_000)
+	}
+	return fmt.Sprintf("%d", n)
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -184,6 +184,51 @@ Rotation requires a running daemon so its in-memory token flips atomically
 with the on-disk one. In the [Home Assistant app](home-assistant.md), use the
 `rotate_token` toggle on the Configuration page instead.
 
+### `podiom usage`
+
+Show provider plan-limit usage per profile. Reports Claude and Codex plan-limit
+utilization (5-hour and weekly windows) for each configured auth profile.
+
+```
+podiom usage
+podiom usage --json
+podiom usage --refresh
+```
+
+| Flag | Description |
+| --- | --- |
+| `--json` | Print machine-readable JSON. |
+| `--refresh` | Force a live re-fetch instead of cached data. |
+
+### `podiom usage tokens`
+
+Show token usage across sessions. Aggregates and displays token usage (input,
+output, cache) from all sessions, optionally filtered by agent.
+
+```
+podiom usage tokens
+podiom usage tokens --agent jared
+podiom usage tokens --json
+```
+
+| Flag | Description |
+| --- | --- |
+| `--agent` | Filter by agent name. |
+| `--json` | Output as JSON. |
+
+Without `--agent`, displays a summary table of all agents:
+
+```
+AGENT     SESSIONS  INPUT    OUTPUT   CACHE_R  CACHE_W  TOTAL
+jared     47        1.9M     449.2K   50.0K    10.0K    2.4M
+builder   12        523.1K   98.2K    0        0        621.3K
+────────  ────────  ──────── ──────── ──────── ──────── ────────
+TOTAL     59        2.4M     547.4K   50.0K    10.0K    3.0M
+```
+
+With `--agent`, displays detailed breakdown for that agent including per-model
+usage.
+
 ### `podiom onboard` / `podiom setup`
 
 Run the first-use wizard.


### PR DESCRIPTION
## What

Adds `podiom usage tokens` command to display token usage across sessions.

## Usage

```bash
podiom usage tokens                # Summary table of all agents
podiom usage tokens --agent juno   # Detailed view for one agent
podiom usage tokens --json         # JSON output
```

## Example Output

```
AGENT     SESSIONS  INPUT     OUTPUT    CACHE_R   CACHE_W   TOTAL
juno      3         156.0K    42.0K     8.5K      3.2K      209.7K
────────  ────────  ────────  ────────  ────────  ────────  ────────
TOTAL     3         156.0K    42.0K     8.5K      3.2K      209.7K
```

## Functions Added

| Function | Purpose |
|----------|---------|
| `newUsageTokensCmd` | Creates the `tokens` subcommand with `--agent` and `--json` flags |
| `aggregateTokenUsage` | Groups sessions by agent and sums their token usage |
| `aggregateByModel` | Groups sessions by model for the detail view |
| `formatTokensTable` | Renders the summary table |
| `formatTokensDetail` | Renders the single-agent detail view |
| `formatTokenCount` | Formats numbers as human-readable (e.g., 156000 → 156.0K) |

## Notes

- Uses existing `client.ListSessions()` - no new API endpoints needed
- Token data is already tracked by Podiom in `sessions.usage_*` columns

Closes #19