### PR TITLE
docs: add Homebrew install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ authentication and policy controls.
 
 Install the latest release on macOS or Linux:
 
+Homebrew users can install Podiom with `brew install Podiom/podiom/podiom`.
+
 ```sh
 curl -fsSL https://github.com/Podiom/Podiom/releases/latest/download/install.sh | bash
 ```


### PR DESCRIPTION
## Summary

Adds the new Podiom Homebrew tap as an install option in the README Get started section.

The tap lives at https://github.com/Podiom/homebrew-podiom and installs both `podiom` and `podiomd` from the `v0.1.182` release artifacts.

## Validation

- Created and verified `Podiom/homebrew-podiom` formula against release `v0.1.182`.
- Ran a local Homebrew checkout install: `brew install Podiom/podiom/podiom`.
- Verified installed binaries report `podiom version v0.1.182 (d34ac20)` and `podiomd version v0.1.182 (d34ac20)`.
- Ran `ruby -c Formula/podiom.rb` with Homebrew portable Ruby: `Syntax OK`.

Note: `brew test` did not reach the formula test block in this environment because Homebrew developer-mode gem setup requires `make`, which is absent here.