### PR TITLE
test(hamode): add unit tests for Detect

### DIFF
--- a/internal/hamode/hamode_test.go
+++ b/internal/hamode/hamode_test.go
@@ -1,0 +1,52 @@
+package hamode
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T)
+		want  bool
+	}{
+		{
+			name: "unset",
+			setup: func(t *testing.T) {
+				if prev, ok := os.LookupEnv(EnvSupervisorToken); ok {
+					if err := os.Unsetenv(EnvSupervisorToken); err != nil {
+						t.Fatalf("failed to unset %s: %v", EnvSupervisorToken, err)
+					}
+					t.Cleanup(func() {
+						os.Setenv(EnvSupervisorToken, prev)
+					})
+				}
+			},
+			want: false,
+		},
+		{
+			name: "set to non-empty",
+			setup: func(t *testing.T) {
+				t.Setenv(EnvSupervisorToken, "mock-supervisor-token")
+			},
+			want: true,
+		},
+		{
+			name: "set to empty string",
+			setup: func(t *testing.T) {
+				t.Setenv(EnvSupervisorToken, "")
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup(t)
+			if got := Detect(); got != tc.want {
+				t.Errorf("Detect() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #34

This is a tests-only patch adding unit test coverage for `hamode.Detect()` in `internal/hamode/hamode_test.go`.

### Covered Cases
Table-driven tests covering the three environment states for `SUPERVISOR_TOKEN`:
1. `unset`: `SUPERVISOR_TOKEN` is unset in the process environment -> `Detect()` returns `false`
2. `set to non-empty`: `SUPERVISOR_TOKEN` is set to `"mock-supervisor-token"` via `t.Setenv` -> `Detect()` returns `true`
3. `set to empty string`: `SUPERVISOR_TOKEN` is set to `""` via `t.Setenv` -> `Detect()` returns `false`

### Validation
- `go test ./internal/hamode/... -v` (3/3 subtests pass)
- `go test ./internal/autostart/... ./internal/claudeauth/... ./internal/discovery/... -v` (pass)
- `gofmt -d ./internal/hamode/hamode_test.go` (clean)
- `go vet ./internal/hamode/...` (clean)
- `git diff --check` (clean)
