### PR TITLE
test(marketplace): add table tests for normalizeSkillsMPUpdatedAt

### DIFF
--- a/internal/marketplace/skillsmp_test.go
+++ b/internal/marketplace/skillsmp_test.go
@@ -1,0 +1,25 @@
+package marketplace
+
+import "testing"
+
+func TestNormalizeSkillsMPUpdatedAt(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"unix timestamp", "1700000000", "2023-11-14T22:13:20Z"},
+		{"negative timestamp", "-1", "1969-12-31T23:59:59Z"},
+		{"already formatted date", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z"},
+		{"out of int64 range", "99999999999999999999999", "99999999999999999999999"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeSkillsMPUpdatedAt(tt.in); got != tt.want {
+				t.Fatalf("normalizeSkillsMPUpdatedAt(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #47 (remaining scope)

Adds internal/marketplace/skillsmp_test.go with a table-driven test for normalizeSkillsMPUpdatedAt in skillsmp.go, covering the previously uncovered branches: empty and whitespace-only input, a Unix timestamp formatted to RFC3339 UTC, a negative timestamp, an already-formatted non-numeric date returned unchanged, and an out-of-int64-range numeric string that falls through unchanged.

Per the maintainer note, kebab and dedupKey are already covered, so this only touches normalizeSkillsMPUpdatedAt and does not add a TestKebab. No production changes.