### PR TITLE
fix: Fix mobile chat chip menus

### DIFF
--- a/web/src/lib/RunTargetPicker.svelte
+++ b/web/src/lib/RunTargetPicker.svelte
@@ -786,12 +786,19 @@
       margin-left: 0;
     }
     .run-target.toolbar .rt-menu {
+      position: fixed;
+      z-index: 45;
       right: calc(12px + env(safe-area-inset-right));
-      bottom: 47px;
+      bottom: var(--composer-mobile-menu-bottom, 119px);
       left: calc(12px + env(safe-area-inset-left));
       width: auto;
       min-width: 0;
       max-width: none;
+      max-height: min(340px, calc(100vh - var(--composer-mobile-menu-bottom, 119px) - 12px - env(safe-area-inset-top)));
+      max-height: min(340px, calc(100dvh - var(--composer-mobile-menu-bottom, 119px) - 12px - env(safe-area-inset-top)));
+      overflow-y: auto;
+      overscroll-behavior: contain;
+      -webkit-overflow-scrolling: touch;
     }
   }
 </style>

--- a/web/src/lib/UsageChip.svelte
+++ b/web/src/lib/UsageChip.svelte
@@ -409,12 +409,17 @@
       margin-left: 0;
     }
     .usage-pop {
+      position: fixed;
+      z-index: 45;
       right: calc(12px + env(safe-area-inset-right));
-      bottom: 47px;
+      bottom: var(--composer-mobile-menu-bottom, 119px);
       left: calc(12px + env(safe-area-inset-left));
       width: auto;
-      max-height: min(320px, calc(100dvh - 130px));
+      max-height: min(340px, calc(100vh - var(--composer-mobile-menu-bottom, 119px) - 12px - env(safe-area-inset-top)));
+      max-height: min(340px, calc(100dvh - var(--composer-mobile-menu-bottom, 119px) - 12px - env(safe-area-inset-top)));
       overflow-y: auto;
+      overscroll-behavior: contain;
+      -webkit-overflow-scrolling: touch;
     }
   }
 </style>

--- a/web/src/pages/Chat.svelte
+++ b/web/src/pages/Chat.svelte
@@ -4628,6 +4628,7 @@
     border-top: 1px solid var(--line);
     background: var(--surface-2);
     position: relative;
+    --composer-mobile-menu-bottom: 119px;
   }
 
   .slash-menu {
@@ -5577,13 +5578,18 @@
     }
 
     .composer-meta .dd-menu.up {
+      position: fixed;
+      z-index: 45;
       right: calc(12px + env(safe-area-inset-right));
-      bottom: 47px;
+      bottom: var(--composer-mobile-menu-bottom);
       left: calc(12px + env(safe-area-inset-left));
       width: auto;
       min-width: 0;
-      max-height: min(280px, calc(100dvh - 130px));
+      max-height: min(340px, calc(100vh - var(--composer-mobile-menu-bottom) - 12px - env(safe-area-inset-top)));
+      max-height: min(340px, calc(100dvh - var(--composer-mobile-menu-bottom) - 12px - env(safe-area-inset-top)));
       overflow-y: auto;
+      overscroll-behavior: contain;
+      -webkit-overflow-scrolling: touch;
     }
 
     .composer-meta .dd-wrap,


### PR DESCRIPTION
## Summary
- Keep mobile chat chip menus visible above the composer instead of clipped by the horizontal chip scroller
- Add viewport/safe-area-aware height limits and touch scrolling for project, permission, run-target, and usage chip menus

## Test
- npm run check -w web
- npm run build -w web