### PR TITLE
Test/helper functions in tools

### DIFF
--- a/internal/notify/relay_test.go
+++ b/internal/notify/relay_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -70,6 +71,12 @@ func (f *fakeRelay) Push(_ context.Context, _, idempotencyKey string, req pushRe
 		return pushResponse{}, f.pushErrs[attempt]
 	}
 	return f.pushResp, nil
+}
+
+type errorReader struct{}
+
+func (errorReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("read failed")
 }
 
 // newRelayChannel builds a channel over the fake and a real store, with enrollment state
@@ -554,5 +561,51 @@ func TestRelayChannelWithNoDevicesDoesNotCallTheRelay(t *testing.T) {
 	if len(results) != 0 || len(fake.pushes) != 0 || fake.enrollments != 0 {
 		t.Errorf("results=%d pushes=%d enrollments=%d, want 0/0/0 — nothing to deliver to means "+
 			"no reason to contact Podiom infrastructure", len(results), len(fake.pushes), fake.enrollments)
+	}
+}
+
+func TestRelayErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		body io.Reader
+		want string
+	}{
+		{name: "Valid JSON", body: strings.NewReader(`{"error":{"code":"...","message":"rate limited"}}`), want: "rate limited"},
+		{name: "Valid JSON with no message", body: strings.NewReader(`{"error":{"code":"..."}}`), want: `{"error":{"code":"..."}}`},
+		{name: "Plan test", body: strings.NewReader(`"message":"rate limited"`), want: `"message":"rate limited"`},
+		{name: "Long plan text", body: strings.NewReader(strings.Repeat("a", 5000)), want: strings.Repeat("a", 4096)},
+		{name: "Empty body", body: strings.NewReader(""), want: ""},
+		{name: "Invalid reader", body: errorReader{}, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := relayErrorMessage(tt.body)
+			if got != tt.want {
+				t.Errorf("want: %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{name: "Postive integer", raw: "30", want: 30 * time.Second},
+		{name: "Negtive number", raw: "-5", want: 0},
+		{name: "Non-numeric", raw: "soon", want: 0},
+		{name: "Decimal", raw: "5.5", want: 0},
+		{name: "Zero", raw: "0", want: 0},
+		{name: "Empty string", raw: "", want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseRetryAfter(tt.raw)
+			if got != tt.want {
+				t.Errorf("for: %s, want: %v, got: %v", tt.raw, tt.want, got)
+			}
+		})
 	}
 }

--- a/internal/tools/install_test.go
+++ b/internal/tools/install_test.go
@@ -1,0 +1,37 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTail(t *testing.T) {
+	extraLength := 500
+	extraOutputTail := outputTail + extraLength
+	tests := []struct {
+		name        string
+		inputString string
+		want        string
+	}{
+		{name: "short input",
+			inputString: "Reading package lists... Done \nBuilding dependency tree... Done",
+			want:        "Reading package lists... Done \nBuilding dependency tree... Done"},
+		{name: "boundary length input",
+			inputString: strings.Repeat("a", outputTail),
+			want:        strings.Repeat("a", outputTail)},
+		{name: "Long input",
+			inputString: strings.Repeat("a", extraOutputTail),
+			want:        "…" + strings.Repeat("a", outputTail)},
+		{name: "Long input with Leading/trailing whitespace",
+			inputString: "  " + strings.Repeat("a", extraOutputTail) + "  ",
+			want:        "…" + strings.Repeat("a", outputTail)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tail(tt.inputString)
+			if got != tt.want {
+				t.Errorf("for: %s, want: %q, got: %q", tt.name, tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -211,6 +211,48 @@ func TestStubbedInstallerSuccess(t *testing.T) {
 	}
 }
 
+func TestNPMPackageName(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  string
+		want string
+	}{
+		{name: "Unscoped with version", pkg: "typescript@5.3.3", want: "typescript"},
+		{name: "Unscoped, no version", pkg: "typescript", want: "typescript"},
+		{name: "Scoped with version", pkg: "@modelcontextprotocol/server-filesystem@1.0.0", want: "@modelcontextprotocol/server-filesystem"},
+		{name: "Scoped, no version", pkg: "@modelcontextprotocol", want: "@modelcontextprotocol"},
+		{name: "Just @", pkg: "@", want: "@"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := npmPackageName(tt.pkg)
+			if got != tt.want {
+				t.Errorf("for: %s, want: %q, got: %q", tt.name, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestUVPackageName(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  string
+		want string
+	}{
+		{name: "Unscoped with version", pkg: "requests==2.31.0", want: "requests"},
+		{name: "No == present", pkg: "typescript@5.3.3", want: "typescript@5.3.3"},
+		{name: "", pkg: "requests==2.31.0; sys_platform == 'win32'", want: "requests"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := uvPackageName(tt.pkg)
+			if got != tt.want {
+				t.Errorf("for: %s, want: %q, got: %q", tt.name, tt.want, got)
+			}
+		})
+	}
+}
+
 // rewriteTransport sends every request to the test server regardless of URL.
 type rewriteTransport struct{ base string }
 


### PR DESCRIPTION
Fixes #76

## Why
Increases test coverage for `npmPackageName`, `uvPackageName`, and `tail` in `internal/tools`.

## Changes
- Added unit tests for `npmPackageName`, `uvPackageName`, and `tail`.
- New file `internal/tools/install_test.go` created for unit testing `tail`.

Please let me know if you'd like any changes made.