### PR TITLE
test: add unit test for npmPackageName, uvPackageName and tail

### DIFF
--- a/internal/tools/install_test.go
+++ b/internal/tools/install_test.go
@@ -1,0 +1,37 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTail(t *testing.T) {
+	extraLength := 500
+	extraOutputTail := outputTail + extraLength
+	tests := []struct {
+		name        string
+		inputString string
+		want        string
+	}{
+		{name: "short input",
+			inputString: "Reading package lists... Done \nBuilding dependency tree... Done",
+			want:        "Reading package lists... Done \nBuilding dependency tree... Done"},
+		{name: "boundary length input",
+			inputString: strings.Repeat("a", outputTail),
+			want:        strings.Repeat("a", outputTail)},
+		{name: "Long input",
+			inputString: strings.Repeat("a", extraOutputTail),
+			want:        "…" + strings.Repeat("a", outputTail)},
+		{name: "Long input with Leading/trailing whitespace",
+			inputString: "  " + strings.Repeat("a", extraOutputTail) + "  ",
+			want:        "…" + strings.Repeat("a", outputTail)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tail(tt.inputString)
+			if got != tt.want {
+				t.Errorf("for: %s, want: %q, got: %q", tt.name, tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -211,6 +211,48 @@ func TestStubbedInstallerSuccess(t *testing.T) {
 	}
 }
 
+func TestNPMPackageName(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  string
+		want string
+	}{
+		{name: "Unscoped with version", pkg: "typescript@5.3.3", want: "typescript"},
+		{name: "Unscoped, no version", pkg: "typescript", want: "typescript"},
+		{name: "Scoped with version", pkg: "@modelcontextprotocol/server-filesystem@1.0.0", want: "@modelcontextprotocol/server-filesystem"},
+		{name: "Scoped, no version", pkg: "@modelcontextprotocol", want: "@modelcontextprotocol"},
+		{name: "Just @", pkg: "@", want: "@"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := npmPackageName(tt.pkg)
+			if got != tt.want {
+				t.Errorf("for: %s, want: %q, got: %q", tt.name, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestUVPackageName(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  string
+		want string
+	}{
+		{name: "Unscoped with version", pkg: "requests==2.31.0", want: "requests"},
+		{name: "No == present", pkg: "typescript@5.3.3", want: "typescript@5.3.3"},
+		{name: "", pkg: "requests==2.31.0; sys_platform == 'win32'", want: "requests"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := uvPackageName(tt.pkg)
+			if got != tt.want {
+				t.Errorf("for: %s, want: %q, got: %q", tt.name, tt.want, got)
+			}
+		})
+	}
+}
+
 // rewriteTransport sends every request to the test server regardless of URL.
 type rewriteTransport struct{ base string }
 


### PR DESCRIPTION
Fixes #76

## Why
Increases test coverage for `npmPackageName`, `uvPackageName`, and `tail` in `internal/tools`.

## Changes
Added unit tests for `npmPackageName`, `uvPackageName`, and `tail`.
New file `internal/tools/install_test.go` created for unit testing `tail`.
Please let me know if you'd like any changes made.