### PR TITLE
test(marketplace): cover joinRel and refFromID

### DIFF
--- a/internal/marketplace/githuburl_helpers_test.go
+++ b/internal/marketplace/githuburl_helpers_test.go
@@ -1,0 +1,47 @@
+package marketplace
+
+import "testing"
+
+func TestJoinRel(t *testing.T) {
+	tests := []struct {
+		name      string
+		base, sub string
+		want      string
+	}{
+		{name: "both non-empty", base: "a", sub: "b", want: "a/b"},
+		{name: "empty base", sub: "b", want: "b"},
+		{name: "empty sub", base: "a", want: "a"},
+		{name: "both empty"},
+		{name: "trim slashes", base: "/a/", sub: "/b/", want: "a/b"},
+		{name: "both empty after trim", base: "/", sub: "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := joinRel(tt.base, tt.sub); got != tt.want {
+				t.Errorf("joinRel(%q, %q) = %q, want %q", tt.base, tt.sub, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRefFromID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want SkillRef
+	}{
+		{name: "plain id", id: "hello", want: SkillRef{Owner: "owner", Repo: "repo", Path: "hello"}},
+		{name: "trim slashes", id: "/a/b/", want: SkillRef{Owner: "owner", Repo: "repo", Path: "a/b"}},
+		{name: "nested path", id: "skills/hello/SKILL.md", want: SkillRef{Owner: "owner", Repo: "repo", Path: "skills/hello/SKILL.md"}},
+		{name: "empty id", want: SkillRef{Owner: "owner", Repo: "repo"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := refFromID("owner", "repo", tt.id); got != tt.want {
+				t.Errorf("refFromID(%q, %q, %q) = %+v, want %+v", "owner", "repo", tt.id, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION



## Summary

Adds table-driven unit tests for two small marketplace helper functions that previously had no direct coverage:

- `joinRel`
- `refFromID`

## Coverage

The tests cover:

- Empty inputs
- Leading and trailing slash trimming
- Joining non-empty relative paths
- Plain and nested skill IDs
- Preserving owner and repository values when the ID is empty

## Verification

```bash
export PATH=/data/podiom/projects/podiom/.tools/go1.26.5/bin:$PATH
go test ./internal/marketplace/... -run 'TestJoinRel|TestRefFromID' -v

```

#73