### PR TITLE
test(config): cover provider registries and sequenceEqual

### DIFF
--- a/internal/config/editor_test.go
+++ b/internal/config/editor_test.go
@@ -5,7 +5,31 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
+
+func TestSequenceEqual(t *testing.T) {
+	tests := []struct {
+		name   string
+		node   *yaml.Node
+		values []string
+		want   bool
+	}{
+		{name: "non-sequence", node: &yaml.Node{Kind: yaml.MappingNode}, values: []string{"a"}, want: false},
+		{name: "different length", node: &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{{Value: "a"}}}, values: []string{"a", "b"}, want: false},
+		{name: "different value", node: &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{{Value: "a"}, {Value: "c"}}}, values: []string{"a", "b"}, want: false},
+		{name: "matching values", node: &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{{Value: "a"}, {Value: "b"}}}, values: []string{"a", "b"}, want: true},
+		{name: "both empty", node: &yaml.Node{Kind: yaml.SequenceNode}, values: nil, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sequenceEqual(tt.node, tt.values); got != tt.want {
+				t.Fatalf("sequenceEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestRemoveAgentRemovesOnlyMatchingEntryAndKeepsConfigValid(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -48,6 +48,38 @@ func TestProviderIDsLabel(t *testing.T) {
 	}
 }
 
+func TestProviders(t *testing.T) {
+	got := Providers()
+	if len(got) != len(providerInfos) {
+		t.Fatalf("Providers() length = %d, want %d", len(got), len(providerInfos))
+	}
+	for i, info := range got {
+		if info.ID != providerInfos[i].ID || info.DisplayName != providerInfos[i].DisplayName {
+			t.Fatalf("Providers()[%d] = %+v, want registry entry %+v", i, info, providerInfos[i])
+		}
+	}
+	got[0] = ProviderInfo{}
+	if Providers()[0].ID != providerInfos[0].ID {
+		t.Fatal("mutating Providers result changed the registry")
+	}
+}
+
+func TestProviderIDs(t *testing.T) {
+	got := ProviderIDs()
+	providers := Providers()
+	if len(got) != len(providers) {
+		t.Fatalf("ProviderIDs() length = %d, want %d", len(got), len(providers))
+	}
+	for i, id := range got {
+		if id != providers[i].ID {
+			t.Fatalf("ProviderIDs()[%d] = %q, want %q", i, id, providers[i].ID)
+		}
+		if !KnownProvider(id) {
+			t.Fatalf("ProviderIDs()[%d] = %q is not a known provider", i, id)
+		}
+	}
+}
+
 func TestProfileDirRoundTrip(t *testing.T) {
 	claude := Profile{Name: "work", Provider: ProviderClaude}
 	claude.SetDir("/tmp/claude-work")


### PR DESCRIPTION
## Summary

Add focused coverage for the provider registries and `sequenceEqual` helper requested in #74. The tests verify registry contents, copy semantics, ordering, and equality edge cases without changing production behavior.

## Validation

- `go test ./internal/config/... -run 'TestProviders|TestProviderIDs|TestSequenceEqual' -v`\n- `go test ./internal/config/...`\n- `go vet ./internal/config/...`\n\nFixes #74