### PR TITLE
test(config): cover sequence node guard

### DIFF
--- a/internal/config/editor_test.go
+++ b/internal/config/editor_test.go
@@ -16,7 +16,7 @@ func TestSequenceEqual(t *testing.T) {
 		values []string
 		want   bool
 	}{
-		{name: "non-sequence", node: &yaml.Node{Kind: yaml.MappingNode}, values: []string{"a"}, want: false},
+		{name: "non-sequence", node: &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{{Value: "a"}}}, values: []string{"a"}, want: false},
 		{name: "different length", node: &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{{Value: "a"}}}, values: []string{"a", "b"}, want: false},
 		{name: "different value", node: &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{{Value: "a"}, {Value: "c"}}}, values: []string{"a", "b"}, want: false},
 		{name: "matching values", node: &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{{Value: "a"}, {Value: "b"}}}, values: []string{"a", "b"}, want: true},


### PR DESCRIPTION
## Summary
- strengthen the existing `sequenceEqual` non-sequence test fixture
- ensure matching content would pass without the `yaml.SequenceNode` guard

Closes #88.

## Verification
- `go test ./internal/config -run '^TestSequenceEqual$' -count=1`
- `go test ./internal/config -run '^TestSequenceEqual/non-sequence$' -count=1`
- `go fmt ./internal/config`
- `git diff --check`

The full `go test ./...` run reaches unrelated pre-existing Windows permission/path expectation failures in `internal/config`.