### PR TITLE
test(schedule): cover shipped schedule examples with a regression test

### DIFF
--- a/internal/schedule/examples_test.go
+++ b/internal/schedule/examples_test.go
@@ -1,0 +1,41 @@
+package schedule
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestShippedScheduleExamplesParse(t *testing.T) {
+	paths, err := filepath.Glob(filepath.Join("..", "..", "examples", "schedules", "*.md"))
+	if err != nil {
+		t.Fatalf("glob schedule examples: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no schedule examples found")
+	}
+
+	parsed := make(map[string]Schedule, len(paths))
+	for _, path := range paths {
+		schedule, err := Parse(path)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		parsed[filepath.Base(path)] = schedule
+	}
+
+	digest, ok := parsed["project-digest-every.md"]
+	if !ok {
+		t.Fatal("project-digest-every.md was not parsed")
+	}
+	if digest.Agent != "jared" || digest.Project != "launch-kit" || digest.Every != "6h" || digest.Cron != "" {
+		t.Fatalf("unexpected interval example: %+v", digest)
+	}
+
+	health, ok := parsed["repo-health-daily.md"]
+	if !ok {
+		t.Fatal("repo-health-daily.md was not parsed")
+	}
+	if health.Agent != "jared" || health.Project != "launch-kit" || health.Cron != "0 8 * * *" || health.Every != "" {
+		t.Fatalf("unexpected cron example: %+v", health)
+	}
+}


### PR DESCRIPTION
## Issue

Closes #91.

## Background

The shipped schedule examples were not covered by regression tests, so changes to the real parser could silently break the cookbook files.

## Changes

- Add a test that discovers every `examples/schedules/*.md` file.
- Parse each file through the production `schedule.Parse` function.
- Assert the documented agent, project, and mutually exclusive cron/every triggers for both shipped examples.

## Compatibility

This changes tests only and has no runtime or configuration impact.

## Verification

- `gofmt -w internal/schedule/examples_test.go` — passed.
- `go test ./internal/schedule` — passed.
- `go vet ./internal/schedule` — passed.
- `git diff --check` — passed.

## Limitations

The test covers the schedule examples because those are the example files with an exported production loader; other cookbook formats are not parsed by this package.
