### PR TITLE
test(marketplace): cover rootLabels

### DIFF
--- a/internal/marketplace/installed_test.go
+++ b/internal/marketplace/installed_test.go
@@ -1,0 +1,29 @@
+package marketplace
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/Podiom/Podiom/internal/skills"
+)
+
+func TestRootLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		srcs []skills.Source
+		want []string
+	}{
+		{name: "nil input", srcs: nil, want: []string{}},
+		{name: "one source", srcs: []skills.Source{"project"}, want: []string{"project"}},
+		{name: "multiple sources", srcs: []skills.Source{"managed", "project"}, want: []string{"managed", "project"}},
+		{name: "duplicate sources", srcs: []skills.Source{"managed", "managed"}, want: []string{"managed", "managed"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rootLabels(tt.srcs)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("Want: %v, got %v", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #105 
## Why 
- `rootLabels` has zero coverage

## Changes 
- Added unit test `TestRootLabels` in a new file `internal/marketplace/installed_test.go`

Please let me know if you would like any changes made. 