### PR TITLE
fix(cli): show empty agent list state

### DIFF
--- a/cmd/podiom/main.go
+++ b/cmd/podiom/main.go
@@ -730,6 +730,10 @@ func newAgentsListCmd(addr *string) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if len(agents) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "no agents yet")
+				return nil
+			}
 			for _, agent := range agents {
 				fmt.Printf("%s\tprovider=%s\tprofile=%s\tmodel=%s\teffort=%s\tpermission=%s\tfallback=%s\n",
 					agent.Name, agent.Provider, agent.Profile, agent.Model, agent.Effort, agent.PermissionMode,

--- a/cmd/podiom/main_test.go
+++ b/cmd/podiom/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -58,6 +61,29 @@ func TestAgentsUpdateRejectsYesWithoutGenerateSoul(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--yes only applies with --generate-soul") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAgentsListPrintsEmptyState(t *testing.T) {
+	t.Setenv("PODIOM_HOME", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/agents" {
+			t.Fatalf("request path = %q, want /api/agents", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, "[]")
+	}))
+	t.Cleanup(srv.Close)
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	cmd := newAgentsListCmd(&addr)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := out.String(), "no agents yet\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## What changed

- print `no agents yet` when `podiom agents list` receives an empty result
- add an HTTP-backed CLI regression test that asserts the user-visible output
- keep the existing `schedules list` empty-state message unchanged

Fixes #97

## Testing

- `go test ./cmd/podiom -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- built `podiom` and `podiomd`, started the daemon with a fresh `PODIOM_HOME`, and verified:
  - `podiom agents list` → `no agents yet`
  - `podiom schedules list` → existing empty-state guidance

Developed with assistance from OpenAI Codex. I reviewed the diff and all reported test results before submission.