### PR TITLE
test(claudeauth): cover parseCredentials

### DIFF
--- a/internal/claudeauth/claudeauth_test.go
+++ b/internal/claudeauth/claudeauth_test.go
@@ -3,8 +3,52 @@ package claudeauth
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
+
+func TestParseCredentials(t *testing.T) {
+	tests := []struct {
+		name             string
+		wantCredentials  Credentials
+		wantErrorMessage string
+		raw              []byte
+	}{
+		{name: "valid input",
+			wantCredentials:  Credentials{"test-access-token", []string{"user:read", "messages:write"}, 4102444800000, "test"},
+			wantErrorMessage: "",
+			raw:              []byte(`{"claudeAiOauth": {"accessToken": "test-access-token", "refreshToken": "test-refresh-token", "expiresAt": 4102444800000, "scopes": ["user:read", "messages:write"], "subscriptionType": "test"}}`)},
+
+		{name: "empty input",
+			wantCredentials:  Credentials{},
+			wantErrorMessage: "parse claude credentials: unexpected end of JSON input",
+			raw:              []byte{}},
+
+		{name: "missing the oauth key entirely",
+			wantCredentials:  Credentials{},
+			wantErrorMessage: "",
+			raw:              []byte(`{}`)},
+
+		{name: "valid json but not json object",
+			wantCredentials:  Credentials{},
+			wantErrorMessage: "parse claude credentials: json: cannot unmarshal string into Go value of type claudeauth.credentialsFile",
+			raw:              []byte(`"not an object"`)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCredentials, gotError := parseCredentials(tt.raw)
+			if gotError == nil && tt.wantErrorMessage != "" {
+				t.Fatalf("expected error, want: %v, got: %v", tt.wantErrorMessage, nil)
+			}
+			if gotError != nil && gotError.Error() != tt.wantErrorMessage {
+				t.Fatalf("unexpected error, want: %v, got: %v", tt.wantErrorMessage, gotError.Error())
+			}
+			if !reflect.DeepEqual(gotCredentials, tt.wantCredentials) {
+				t.Errorf("unexpected credentials, want: %v, got: %v", tt.wantCredentials, gotCredentials)
+			}
+		})
+	}
+}
 
 func TestKeychainService(t *testing.T) {
 	// A custom CLAUDE_CONFIG_DIR maps to the base service name suffixed with the


### PR DESCRIPTION
Fixes #101 

## Why
- `parseCredentials` in `internal/claudeauth/claudeauth.go` has zero coverage

## Changes
- Added in a unit test for `parseCredentials`

Please let me know if you would like an changes made.