### PR TITLE
refactor(projects): removed sameStrings

### DIFF
--- a/internal/projects/projects.go
+++ b/internal/projects/projects.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -385,7 +386,7 @@ func (l *Ledger) SyncRoadmaps(byProject map[string][]string) error {
 		if next == nil {
 			next = []string{}
 		}
-		if !sameStrings(file.Projects[i].Roadmap, next) {
+		if !slices.Equal(file.Projects[i].Roadmap, next) {
 			file.Projects[i].Roadmap = append([]string(nil), next...)
 			changed = true
 		}
@@ -426,18 +427,6 @@ func (l *Ledger) write(file ledgerFile) error {
 		return fmt.Errorf("write projects.yaml: %w", err)
 	}
 	return nil
-}
-
-func sameStrings(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func (p *Project) UnmarshalYAML(value *yaml.Node) error {


### PR DESCRIPTION
Fixes #100 

## Why
- No test coverage of `sameStrings` 

## Changes 
- Removed `sameStrings` and replace with `slices.Equal. And they effectively do the same thing. And removes the need to test `sameStrings`. 

Please let me know if you would like any changes.