### PR TITLE
fix: hide duplicate agent constraint errors

### DIFF
--- a/internal/server/agents_test.go
+++ b/internal/server/agents_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Podiom/Podiom/internal/adapter"
@@ -34,6 +35,31 @@ func TestDeleteAgentRejectsConfirmationMismatch(t *testing.T) {
 	}
 	if _, err := srv.core.GetAgent(ctx, "atlas"); err != nil {
 		t.Fatalf("agent should remain after mismatch: %v", err)
+	}
+}
+
+func TestCreateAgentDuplicateNameUsesHumanError(t *testing.T) {
+	_, srv, cleanup := newAgentAPITestServer(t)
+	defer cleanup()
+
+	body := `{"name":"atlas","provider":"claude","permission_mode":"approve"}`
+	first := httptest.NewRecorder()
+	srv.handleAgents(first, httptest.NewRequest(http.MethodPost, "/api/agents", bytes.NewBufferString(body)))
+	if first.Code != http.StatusOK {
+		t.Fatalf("first create status = %d, want 200; body=%s", first.Code, first.Body.String())
+	}
+
+	second := httptest.NewRecorder()
+	srv.handleAgents(second, httptest.NewRequest(http.MethodPost, "/api/agents", bytes.NewBufferString(body)))
+	if second.Code != http.StatusBadRequest {
+		t.Fatalf("second create status = %d, want 400; body=%s", second.Code, second.Body.String())
+	}
+	got := strings.TrimSpace(second.Body.String())
+	if got != `agent "atlas": already exists` {
+		t.Fatalf("duplicate create body = %q", got)
+	}
+	if strings.Contains(got, "UNIQUE constraint") || strings.Contains(got, "constraint failed") {
+		t.Fatalf("duplicate create leaked raw sqlite error: %q", got)
 	}
 }
 

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -12,6 +12,9 @@ import (
 // ErrNotFound reports that a requested store row does not exist.
 var ErrNotFound = errors.New("not found")
 
+// ErrAlreadyExists reports that a row cannot be created because its key is in use.
+var ErrAlreadyExists = errors.New("already exists")
+
 // CreateAgent inserts a durable agent definition.
 func (s *Store) CreateAgent(ctx context.Context, a Agent) (Agent, error) {
 	fallback, err := json.Marshal(a.Fallback)
@@ -28,6 +31,9 @@ func (s *Store) CreateAgent(ctx context.Context, a Agent) (Agent, error) {
 		a.Name, a.Provider, a.Profile, a.Model, a.Effort, a.PermissionMode, string(fallback), string(mcpServers), a.MCPConfig,
 	)
 	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed: agents.name") {
+			return Agent{}, fmt.Errorf("agent %q: %w", a.Name, ErrAlreadyExists)
+		}
 		return Agent{}, fmt.Errorf("create agent %q: %w", a.Name, err)
 	}
 	return s.GetAgent(ctx, a.Name)


### PR DESCRIPTION
## What
Fixes #111. Duplicate agent creation no longer exposes SQLite unique-constraint text.

## Fix
Map the `agents.name` unique-constraint failure to `store.ErrAlreadyExists` so the API returns `agent "<name>": already exists`.

## Test
Adds `TestCreateAgentDuplicateNameUsesHumanError` to cover duplicate `/api/agents` creation.