### PR TITLE
fix(daemon): honour PODIOM_ADDR when resolving the listen address

### DIFF
--- a/cmd/podiomd/main.go
+++ b/cmd/podiomd/main.go
@@ -88,6 +88,20 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	// PODIOM_ADDR must move the daemon as well as the CLI, otherwise setting it
+	// makes every command report "podiomd is not running" while it is. The
+	// variable sits above config.yaml, matching the precedence the CLI
+	// documents; unset, config.yaml still decides on its own.
+	addrSource := "config"
+	if env := os.Getenv("PODIOM_ADDR"); env != "" {
+		bind, port, err := parseHostPort(env)
+		if err != nil {
+			return fmt.Errorf("invalid PODIOM_ADDR %q: %w", env, err)
+		}
+		cfg.Server.Bind = bind
+		cfg.Server.Port = port
+		addrSource = "env"
+	}
 	fileLog, closer, err := podiomlog.Open(podiomlog.Options{
 		Dir:           paths.LogsDir,
 		RetentionDays: cfg.Logging.RetentionDays,
@@ -356,7 +370,7 @@ func run() error {
 	// Serve until a termination signal arrives, then shut down gracefully.
 	errc := make(chan error, 1)
 	go func() { errc <- srv.Start() }()
-	log.Info("podiomd listening", "addr", srv.Addr())
+	log.Info("podiomd listening", "addr", srv.Addr(), "source", addrSource)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -370,6 +384,28 @@ func run() error {
 		defer cancel()
 		return srv.Shutdown(shutdownCtx)
 	}
+}
+
+// parseHostPort splits a "host:port" listen address into the parts
+// server.Options expects. Unlike config.yaml, whose server.port range is
+// checked by Config.Validate, an address arriving from the environment is
+// unvalidated input, so the port is checked here.
+func parseHostPort(addr string) (string, int, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, err
+	}
+	if host == "" {
+		return "", 0, fmt.Errorf("no host to bind; want host:port")
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("port %q is not a number", portStr)
+	}
+	if port < 1 || port > 65535 {
+		return "", 0, fmt.Errorf("port out of range: %d", port)
+	}
+	return host, port, nil
 }
 
 func internalCallbackAddr(bind string, port int) string {

--- a/cmd/podiomd/main_test.go
+++ b/cmd/podiomd/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/Podiom/Podiom/internal/notify"
@@ -24,6 +25,55 @@ func TestInternalCallbackAddrNormalizesWildcardBinds(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := internalCallbackAddr(tt.bind, 8099); got != tt.want {
 				t.Fatalf("internalCallbackAddr(%q) = %q, want %q", tt.bind, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseHostPort covers the daemon's read of PODIOM_ADDR. The variable is
+// unvalidated environment input, and a silently mis-parsed address would put the
+// daemon on a port the CLI is not looking at — the exact split PODIOM_ADDR was
+// reported for.
+func TestParseHostPort(t *testing.T) {
+	tests := []struct {
+		name       string
+		addr       string
+		wantBind   string
+		wantPort   int
+		wantErrSub string
+	}{
+		{name: "loopback", addr: "127.0.0.1:8799", wantBind: "127.0.0.1", wantPort: 8799},
+		{name: "hostname", addr: "podiom.local:8799", wantBind: "podiom.local", wantPort: 8799},
+		{name: "ipv4 wildcard", addr: "0.0.0.0:8799", wantBind: "0.0.0.0", wantPort: 8799},
+		{name: "ipv6 loopback", addr: "[::1]:8799", wantBind: "::1", wantPort: 8799},
+		{name: "min port", addr: "127.0.0.1:1", wantBind: "127.0.0.1", wantPort: 1},
+		{name: "max port", addr: "127.0.0.1:65535", wantBind: "127.0.0.1", wantPort: 65535},
+		{name: "no host", addr: ":8799", wantErrSub: "no host to bind"},
+		{name: "no port", addr: "127.0.0.1", wantErrSub: "missing port"},
+		{name: "non-numeric port", addr: "127.0.0.1:http", wantErrSub: "not a number"},
+		{name: "port above range", addr: "127.0.0.1:65536", wantErrSub: "port out of range"},
+		{name: "zero port", addr: "127.0.0.1:0", wantErrSub: "port out of range"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bind, port, err := parseHostPort(tt.addr)
+			if tt.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("parseHostPort(%q) = (%q, %d, nil), want error containing %q",
+						tt.addr, bind, port, tt.wantErrSub)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrSub) {
+					t.Fatalf("parseHostPort(%q) error = %q, want it to contain %q",
+						tt.addr, err.Error(), tt.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseHostPort(%q) returned unexpected error: %v", tt.addr, err)
+			}
+			if bind != tt.wantBind || port != tt.wantPort {
+				t.Fatalf("parseHostPort(%q) = (%q, %d), want (%q, %d)",
+					tt.addr, bind, port, tt.wantBind, tt.wantPort)
 			}
 		})
 	}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,8 +40,11 @@ podiomd
 | `--help` | Show help. |
 | `--version` | Print version and commit. |
 
-Bind address and port come from `config.yaml` (`server.bind`, `server.port`;
-default `127.0.0.1:8787`).
+Bind address and port come from `PODIOM_ADDR` when set, otherwise from
+`config.yaml` (`server.bind`, `server.port`; default `127.0.0.1:8787`).
+`PODIOM_ADDR` moves both binaries: the daemon listens on it and the CLI looks
+there, so the two never disagree. The startup line reports where the value came
+from (`source=env` or `source=config`).
 
 ## `podiom`
 


### PR DESCRIPTION
## What changed

- `podiomd` now resolves its bind address from `PODIOM_ADDR`, above `config.yaml` and matching the precedence `docs/cli.md` already documents for the CLI, so setting the variable moves both binaries together.
- The startup line reports where the resolved value came from: `addr=127.0.0.1:8799 source=env`.
- `docs/cli.md` states plainly that the variable configures both binaries.
- A new `parseHostPort` rejects an empty host and a port outside 1-65535, so a malformed value fails at startup with a clear message rather than binding somewhere unexpected.

Fixes #98

## Which of the two options, and why

I changed the daemon's behaviour rather than only documenting the split. `docs/cli.md` describes `PODIOM_ADDR` as the "Daemon address" with nothing saying it is client-side only, and running the pair on a non-default port is a perfectly reasonable thing to try with a variable documented that way. The inconsistency looked like the thing to remove, not the thing to write down.

## Two things worth flagging

- `source` distinguishes `env` from `config`, but not an explicit `server.bind`/`server.port` from the built-in default. `config.Load` applies defaults before the daemon sees the struct, so separating those two would mean re-reading the YAML in `run()`. I left it out rather than guess, since a startup line that infers its own provenance is worse than one that is simply less specific.
- `podiomd` still has no `--addr` flag, so the daemon's chain is `PODIOM_ADDR` -> `config.yaml` -> `127.0.0.1:8787`. I did not add one, to keep this scoped to the reported bug. Happy to if you would rather the two binaries expose the same surface.

## Testing

- `go test ./cmd/podiomd/... -count=1` passes, including new `TestParseHostPort` cases for loopback, hostname, `0.0.0.0`, bracketed IPv6, ports 1 and 65535, and the rejections (`:8799`, `127.0.0.1`, `127.0.0.1:http`, `127.0.0.1:0`, `127.0.0.1:65536`).
- `go vet ./...` and `gofmt -l cmd/podiomd/` are clean.
- Built both binaries and ran each case against a fresh `PODIOM_HOME`, checking the port the daemon actually listened on:
  - `PODIOM_ADDR=127.0.0.1:8799`, nothing else set -> `addr=127.0.0.1:8799 source=env`, and `podiom status` reports `podiomd is live at 127.0.0.1:8799`. Before the change the same run logged `8787` while the CLI reported `podiomd is not running (tried 127.0.0.1:8799)`.
  - variable unset, no `server.*` in `config.yaml` -> `127.0.0.1:8787 source=config`, unchanged.
  - `config.yaml` at `8801`, variable unset -> `127.0.0.1:8801 source=config`, so existing installs keep working.
  - `config.yaml` at `8801` with `PODIOM_ADDR=127.0.0.1:8799` -> `8799 source=env`, env wins.
  - `PODIOM_ADDR=127.0.0.1:99999` -> exits 1 with `invalid PODIOM_ADDR "127.0.0.1:99999": port out of range: 99999` and does not start.
- `go test ./... -count=1` passes 32 of 34 packages. The two failures are 5-second deadline tests unrelated to this change: `internal/adapter` (`TestCodexStreamsTurnAndRelaysApproval`, `TestCodexResumesThreadAfterAppServerRestart`) and `internal/providerlogin` (`TestClaudeLoginScrapesURLAndAcceptsCode`). They look load-dependent rather than real: on a clean `a7862b2` with nothing applied, `internal/adapter` fails the same test with the same 5.00s timeout, and both packages pass when run on their own.
