### PR TITLE
fix(schedule): validate cron expressions

### DIFF
--- a/internal/schedule/schedule.go
+++ b/internal/schedule/schedule.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/Podiom/Podiom/internal/config"
+	cron "github.com/robfig/cron/v3"
 	"gopkg.in/yaml.v3"
 )
 
@@ -170,6 +171,11 @@ func (s Schedule) validate() error {
 	}
 	if s.Cron != "" && s.Every != "" {
 		return fmt.Errorf("set only one of cron or every, not both")
+	}
+	if s.Cron != "" {
+		if _, err := cron.ParseStandard(s.Cron); err != nil {
+			return fmt.Errorf("invalid schedule timing %q: %w", s.Cron, err)
+		}
 	}
 	if s.Every != "" {
 		if _, err := time.ParseDuration(s.Every); err != nil {

--- a/internal/schedule/schedule_test.go
+++ b/internal/schedule/schedule_test.go
@@ -173,6 +173,33 @@ Do a thing.
 	}
 }
 
+func TestParseValidatesCronSpecs(t *testing.T) {
+	dir := t.TempDir()
+	invalid := []string{"not a cron", "99 99 * * *", "* * * *", "@bogus"}
+	for _, spec := range invalid {
+		t.Run("rejects "+spec, func(t *testing.T) {
+			path := writeSchedule(t, dir, Slug("bad-"+spec)+".md", "---\nagent: jared\ncron: \""+spec+"\"\nrun_permission: preapproved\nenabled: true\n---\nbody\n")
+			if _, err := Parse(path); err == nil {
+				t.Fatalf("Parse accepted invalid cron spec %q", spec)
+			}
+		})
+	}
+
+	valid := []string{"0 3 * * *", "*/15 * * * *", "@daily", "@every 1h"}
+	for _, spec := range valid {
+		t.Run("accepts "+spec, func(t *testing.T) {
+			path := writeSchedule(t, dir, Slug("good-"+spec)+".md", "---\nagent: jared\ncron: \""+spec+"\"\nrun_permission: preapproved\nenabled: true\n---\nbody\n")
+			sched, err := Parse(path)
+			if err != nil {
+				t.Fatalf("Parse rejected valid cron spec %q: %v", spec, err)
+			}
+			if sched.CronSpec() != spec {
+				t.Fatalf("CronSpec() = %q, want %q", sched.CronSpec(), spec)
+			}
+		})
+	}
+}
+
 // TestParseWebhookOnlySchedule pins that a webhook is a trigger in its own
 // right: a schedule with no cadence at all is valid, and it registers no cron
 // entry because it has no spec to register.


### PR DESCRIPTION
## Summary

Validate cron expressions while parsing schedule files so invalid schedules are surfaced as invalid instead of appearing healthy with `next=-`.

## Changes

- validate `cron` values with the scheduler's cron parser
- return invalid cron expressions as schedule parse errors
- allow existing CLI handling to print `[invalid] ...`

## Testing

- reproduced the issue with `cron: not-a-cron-expr`
- verified `podiom schedules list` now reports the schedule as invalid
- `go test ./internal/schedule/...` passes

Fixes  #112 