### PR TITLE
test(core): cover firstLine, validateSoulMarkdown, ValidInterviewTopic

### DIFF
--- a/internal/core/project_git_test.go
+++ b/internal/core/project_git_test.go
@@ -626,3 +626,24 @@ func findBackedUp(t *testing.T, projectDir, name string) string {
 	}
 	return ""
 }
+
+func TestFirstLine(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want string
+	}{
+		{name: "multi-line input", s: " abcd \n efgh \n ijkl", want: "abcd"},
+		{name: "single-line", s: " abcd  ", want: "abcd"},
+		{name: "empty string", s: "", want: ""},
+		{name: "all whitespace", s: "    ", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := firstLine(tt.s)
+			if got != tt.want {
+				t.Errorf("invalid first line, want: %q, got: %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/core/soul_test.go
+++ b/internal/core/soul_test.go
@@ -1,9 +1,36 @@
 package core
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
+
+func TestValidateSoulMarkdown(t *testing.T) {
+	tests := []struct {
+		name    string
+		soul    string
+		wantErr error
+	}{
+		{name: "complete", soul: "# Identity, ## Purpose, ## Worldview, ## Working style, ## Voice, ## Strengths, ## Boundaries, ## Calibration notes", wantErr: nil},
+		{name: "incomplete missing ## Voice", soul: "# Identity, ## Purpose, ## Worldview, ## Working style, ## Strengths, ## Boundaries, ## Calibration notes", wantErr: errors.New(`generated SOUL.md missing required section "## Voice"`)},
+		{name: "empty", soul: "", wantErr: errors.New(`generated SOUL.md missing required section "# Identity"`)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr := validateSoulMarkdown(tt.soul)
+			if gotErr != nil && tt.wantErr == nil {
+				t.Fatalf("unexpected error: %s", gotErr.Error())
+			}
+			if gotErr == nil && tt.wantErr != nil {
+				t.Fatalf("expected error: want: %s, got: nil", tt.wantErr.Error())
+			}
+			if tt.wantErr != nil && gotErr.Error() != tt.wantErr.Error() {
+				t.Errorf("invalid error meassage: want: %s, got: %s", tt.wantErr.Error(), gotErr.Error())
+			}
+		})
+	}
+}
 
 func TestSoulPromptCarriesInputsAndRequiredShape(t *testing.T) {
 	prompt := SoulPrompt("juno", "# Identity\n\nName: juno\n\nold soul", SoulGenerateRequest{

--- a/internal/core/user_profile_test.go
+++ b/internal/core/user_profile_test.go
@@ -11,6 +11,26 @@ import (
 	"github.com/Podiom/Podiom/internal/config"
 )
 
+func TestValidInterviewTopic(t *testing.T) {
+	var InterviewTopicFake InterviewTopic = "fale"
+	tests := []struct {
+		name  string
+		topic InterviewTopic
+		want  bool
+	}{
+		{name: "in list", topic: InterviewTopicTechnicalDepth, want: true},
+		{name: "not in list", topic: InterviewTopicFake, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidInterviewTopic(tt.topic)
+			if got != tt.want {
+				t.Errorf("want: %v, got: %v", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestUserProfileReadWriteDelete(t *testing.T) {
 	c, cleanup := newTestCore(t)
 	defer cleanup()


### PR DESCRIPTION
Fixes #116

## Why 
- `firstLine`, `validateSoulMarkdown`, and `ValidInterviewTopic` in `internal/core` have zero coverage`

## Changes
- Add unit for each `firstLine`, `validateSoulMarkdown`, and `ValidInterviewTopic`

Please let me know if you would like any changes.