### PR TITLE
fix(examples)/schedules-enabled-false

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ unattended.
 
 Schedules are Markdown files with YAML frontmatter. Copy one into
 `$PODIOM_HOME/schedules/` (default `~/.podiom/schedules/`), edit the `agent` and
-`project` fields, then list it:
+`project` fields, edit the `enabled` feild to `ture`, then list it:
 
 ```sh
 cp examples/schedules/repo-health-daily.md ~/.podiom/schedules/
@@ -27,6 +27,9 @@ podiom schedules list
 
 `cron:` and `every:` are mutually exclusive. `allowed_tools` is the unattended
 preapproved allow-list; tools not listed are denied automatically.
+
+`enabled` is intentionally set to false to make sure the user sets the `agent` and
+`project` fields.
 
 ## Goals
 

--- a/examples/schedules/project-digest-every.md
+++ b/examples/schedules/project-digest-every.md
@@ -1,9 +1,13 @@
 ---
 # Example: interval project digest using every:, not cron:.
-# Needs: an agent named "jared" and a project id "launch-kit". It works best
+# Needs: an agent named "jared" and a project id "launch-kit".
+# Change both names before copying, if your setup differs.
+# Then set enabled: true to run this schedule. It works best
 # when the project ledger entry has useful notes or instructions.
+
 # What it does when it fires: starts a schedule-origin session and produces a
 # short digest from readable project files and Podiom context.
+
 # Permission note: this intentionally omits Bash. In preapproved mode, any
 # unlisted side-effecting tool is denied automatically.
 agent: jared
@@ -15,7 +19,7 @@ allowed_tools:
   - LS
   - Glob
   - Grep
-enabled: true
+enabled: false
 ---
 
 Write a concise project digest for the last six hours.

--- a/examples/schedules/repo-health-daily.md
+++ b/examples/schedules/repo-health-daily.md
@@ -1,9 +1,12 @@
 ---
 # Example: daily read-only repository health check.
 # Needs: an agent named "jared" and a project id "launch-kit" whose directory is
-# a Git checkout. Change both names before copying if your installation differs.
+# a Git checkout. Change both names before copying, if your setup differs.
+# Then set enabled: true to run this schedule.
+
 # What it does when it fires: starts a schedule-origin session, inspects local
 # repository state, and reports risks. It should not edit files or move tasks.
+
 # Permission note: Bash is allowed so the agent can run read-only git/gh
 # commands. Podiom allow-lists tool names, not individual shell commands.
 agent: jared
@@ -16,7 +19,7 @@ allowed_tools:
   - Glob
   - Grep
   - Bash
-enabled: true
+enabled: false
 ---
 
 Run a read-only repository health check for this project.


### PR DESCRIPTION
Fixes #99

## Why
- Cookbook schedules can be enabled without the `agent` and `project` fields being properly set up.

## Changes
- Set `enabled` to `false` and updated the comment in `examples/schedules/project-digest-every.md` and `examples/schedules/repo-health-daily.md`.
- Updated `examples/README.md` to show that `enabled` is intentionally set to `false`.