### PR TITLE
fix: handle daemon unreachable errors consistently

### DIFF
--- a/cmd/podiom/main.go
+++ b/cmd/podiom/main.go
@@ -28,7 +28,24 @@ import (
 )
 
 func main() {
-	if err := newRootCmd().Execute(); err != nil {
+	root := newRootCmd()
+	root.SilenceErrors = true
+
+	if err := root.Execute(); err != nil {
+		switch {
+		case errors.Is(err, onboard.ErrNoTTY):
+			// The command already printed its no-TTY guidance.
+		case errors.Is(err, client.ErrDaemonUnreachable):
+			flagAddr, _ := root.PersistentFlags().GetString("addr")
+			resolved, resolveErr := resolveAddr(flagAddr)
+			if resolveErr != nil {
+				fmt.Fprintln(os.Stderr, "podiomd is not running.\nStart it with: podiomd")
+			} else {
+				fmt.Fprintf(os.Stderr, "podiomd is not running (tried %s).\nStart it with: podiomd\n", resolved)
+			}
+		default:
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		os.Exit(1)
 	}
 }
@@ -476,10 +493,6 @@ func newStatusCmd(addr *string) *cobra.Command {
 			c := client.New(resolved)
 			h, err := c.Health(context.Background())
 			if err != nil {
-				if errors.Is(err, client.ErrDaemonUnreachable) {
-					fmt.Fprintf(os.Stderr, "podiomd is not running (tried %s).\nStart it with: podiomd\n", resolved)
-					return err
-				}
 				return err
 			}
 			fmt.Printf("podiomd is live at %s\n", resolved)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -718,7 +718,7 @@ func (c *Client) getJSON(ctx context.Context, path string, out any) error {
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %w", ErrDaemonUnreachable, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -745,7 +745,7 @@ func (c *Client) postWithClient(ctx context.Context, hc *http.Client, path strin
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := hc.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %w", ErrDaemonUnreachable, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -495,7 +495,7 @@ func (c *Client) Chat(ctx context.Context, req ChatRequest) (<-chan StreamEvent,
 		httpClient := c.bespokeClient(0)
 		resp, err := httpClient.Do(httpReq)
 		if err != nil {
-			errs <- err
+			errs <- fmt.Errorf("%w: %w", ErrDaemonUnreachable, err)
 			return
 		}
 		defer resp.Body.Close()
@@ -594,7 +594,7 @@ func (c *Client) RunSchedule(ctx context.Context, name string) (store.ScheduleRu
 	}
 	resp, err := c.bespokeClient(0).Do(req)
 	if err != nil {
-		return run, err
+		return run, fmt.Errorf("%w: %w", ErrDaemonUnreachable, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -641,7 +641,7 @@ func (c *Client) Usage(ctx context.Context, refresh bool) ([]usage.Snapshot, err
 	hc := c.bespokeClient(20 * time.Second)
 	resp, err := hc.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrDaemonUnreachable, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -767,7 +767,7 @@ func (c *Client) putJSON(ctx context.Context, path string, in any, out any) erro
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %w", ErrDaemonUnreachable, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -789,7 +789,7 @@ func (c *Client) deleteJSON(ctx context.Context, path string, in any, out any) e
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %w", ErrDaemonUnreachable, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -57,3 +57,44 @@ func TestSharedHelpersMapDaemonUnreachable(t *testing.T) {
 		}
 	})
 }
+
+func TestRemainingDaemonRequestsMapDaemonUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	srv.Close()
+
+	c := New(addr)
+
+	assertUnreachable := func(t *testing.T, err error) {
+		t.Helper()
+		if !errors.Is(err, ErrDaemonUnreachable) {
+			t.Fatalf("error = %v, want ErrDaemonUnreachable", err)
+		}
+	}
+
+	t.Run("PUT", func(t *testing.T) {
+		_, err := c.UpdateProfile(context.Background(), "test", ProfileRequest{})
+		assertUnreachable(t, err)
+	})
+
+	t.Run("DELETE", func(t *testing.T) {
+		err := c.DeleteProfile(context.Background(), "test")
+		assertUnreachable(t, err)
+	})
+
+	t.Run("RUN_SCHEDULE", func(t *testing.T) {
+		_, err := c.RunSchedule(context.Background(), "test")
+		assertUnreachable(t, err)
+	})
+
+	t.Run("USAGE_REFRESH", func(t *testing.T) {
+		_, err := c.Usage(context.Background(), true)
+		assertUnreachable(t, err)
+	})
+
+	t.Run("CHAT", func(t *testing.T) {
+		_, errs := c.Chat(context.Background(), ChatRequest{})
+		err := <-errs
+		assertUnreachable(t, err)
+	})
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -33,4 +34,26 @@ func TestPostLongJSONSendsGatewayToken(t *testing.T) {
 	if gotToken != token {
 		t.Fatalf("gateway token header = %q, want %q", gotToken, token)
 	}
+}
+
+func TestSharedHelpersMapDaemonUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	srv.Close()
+
+	c := New(addr)
+
+	t.Run("GET", func(t *testing.T) {
+		_, err := c.ListProfiles(context.Background())
+		if !errors.Is(err, ErrDaemonUnreachable) {
+			t.Fatalf("ListProfiles error = %v, want ErrDaemonUnreachable", err)
+		}
+	})
+
+	t.Run("POST", func(t *testing.T) {
+		_, err := c.CreateProfile(context.Background(), ProfileRequest{})
+		if !errors.Is(err, ErrDaemonUnreachable) {
+			t.Fatalf("CreateProfile error = %v, want ErrDaemonUnreachable", err)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- map GET- and POST-backed transport failures to `ErrDaemonUnreachable` while preserving the underlying transport error
- centralize the friendly `podiomd`-not-running guidance instead of handling it only in `status`
- add focused regression coverage for both GET- and POST-backed client calls
- preserve the existing exit code behavior

## Testing

- `go vet ./...`
- `go test ./internal/client ./cmd/podiom`
- verified `status` and `projects list` against an unreachable daemon address
- confirmed both commands show the friendly daemon-start guidance once and exit with code `1`

Closes #89