### PR TITLE
test(adapter): cover Codex agent status mappings

### DIFF
--- a/internal/adapter/codex_test.go
+++ b/internal/adapter/codex_test.go
@@ -987,6 +987,52 @@ func TestCodexNativeAgentActivityParsingAndEnrichment(t *testing.T) {
 	}
 }
 
+func TestCodexAgentStateStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		want   string
+	}{
+		{name: "completed", status: "completed", want: "completed"},
+		{name: "errored", status: "errored", want: "failed"},
+		{name: "not found", status: "notFound", want: "failed"},
+		{name: "interrupted", status: "interrupted", want: "cancelled"},
+		{name: "shutdown", status: "shutdown", want: "cancelled"},
+		{name: "unknown", status: "unknown"},
+		{name: "empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := codexAgentStateStatus(tt.status); got != tt.want {
+				t.Fatalf("codexAgentStateStatus(%q) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexSubAgentActivityStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		kind string
+		want string
+	}{
+		{name: "started", kind: "started", want: "started"},
+		{name: "interacted", kind: "interacted", want: "started"},
+		{name: "interrupted", kind: "interrupted", want: "cancelled"},
+		{name: "unknown", kind: "unknown"},
+		{name: "empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := codexSubAgentActivityStatus(tt.kind); got != tt.want {
+				t.Fatalf("codexSubAgentActivityStatus(%q) = %q, want %q", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
 // Codex sends its reasoning twice: as deltas while the turn runs, then whole at
 // turn/completed. Emitting both would duplicate every working note, so the
 // completion copy is dropped once deltas have streamed — and the item-boundary


### PR DESCRIPTION
Closes #143.

Adds table-driven coverage for every documented `codexAgentStateStatus` mapping and for the remaining `codexSubAgentActivityStatus` branches, including unknown and empty inputs.

Verification:

- `go test ./internal/adapter/ -run 'TestCodex(?:AgentStateStatus|SubAgentActivityStatus)$' -count=1 -v`
- `make test`
- `go vet ./...`
- both target functions report 100% coverage
- removing the `notFound` mapping makes the new `not_found` case fail

No runtime behavior or user-facing documentation changes are needed because this PR only locks down the existing private mapping contract.

AI assistance: I used Codex to inspect the implementation and draft the tests, then ran the focused mutation check and the full validation above.
