### PR TITLE
fix(daemon): honor PODIOM_ADDR

### DIFF
--- a/cmd/podiomd/main.go
+++ b/cmd/podiomd/main.go
@@ -88,6 +88,17 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	daemonBind, daemonPort, addrSource, err := resolveDaemonAddr(
+		cfg.Server.Bind,
+		cfg.Server.Port,
+		os.Getenv("PODIOM_ADDR"),
+		res.CreatedConfig,
+	)
+	if err != nil {
+		return err
+	}
+	cfg.Server.Bind = daemonBind
+	cfg.Server.Port = daemonPort
 	fileLog, closer, err := podiomlog.Open(podiomlog.Options{
 		Dir:           paths.LogsDir,
 		RetentionDays: cfg.Logging.RetentionDays,
@@ -356,7 +367,7 @@ func run() error {
 	// Serve until a termination signal arrives, then shut down gracefully.
 	errc := make(chan error, 1)
 	go func() { errc <- srv.Start() }()
-	log.Info("podiomd listening", "addr", srv.Addr())
+	log.Info("podiomd listening", "addr", srv.Addr(), "source", addrSource)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -370,6 +381,26 @@ func run() error {
 		defer cancel()
 		return srv.Shutdown(shutdownCtx)
 	}
+}
+
+func resolveDaemonAddr(configBind string, configPort int, envAddr string, defaultConfig bool) (string, int, string, error) {
+	if envAddr == "" {
+		source := "config"
+		if defaultConfig {
+			source = "default"
+		}
+		return configBind, configPort, source, nil
+	}
+
+	bind, portText, err := net.SplitHostPort(envAddr)
+	if err != nil {
+		return "", 0, "", fmt.Errorf("PODIOM_ADDR must be host:port: %w", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil || port < 1 || port > 65535 {
+		return "", 0, "", fmt.Errorf("PODIOM_ADDR has invalid port %q", portText)
+	}
+	return bind, port, "env", nil
 }
 
 func internalCallbackAddr(bind string, port int) string {

--- a/cmd/podiomd/main_test.go
+++ b/cmd/podiomd/main_test.go
@@ -8,6 +8,41 @@ import (
 	"github.com/Podiom/Podiom/internal/store"
 )
 
+func TestResolveDaemonAddrUsesEnvironmentBeforeConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		env        string
+		wantBind   string
+		wantPort   int
+		wantSource string
+		wantErr    bool
+		defaultCfg bool
+	}{
+		{name: "config fallback", wantBind: "0.0.0.0", wantPort: 8787, wantSource: "config"},
+		{name: "new default config", wantBind: "0.0.0.0", wantPort: 8787, wantSource: "default", defaultCfg: true},
+		{name: "environment override", env: "127.0.0.1:8799", wantBind: "127.0.0.1", wantPort: 8799, wantSource: "env"},
+		{name: "IPv6 environment override", env: "[::1]:8800", wantBind: "::1", wantPort: 8800, wantSource: "env"},
+		{name: "missing port", env: "127.0.0.1", wantErr: true},
+		{name: "invalid port", env: "127.0.0.1:nope", wantErr: true},
+		{name: "out of range port", env: "127.0.0.1:70000", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bind, port, source, err := resolveDaemonAddr("0.0.0.0", 8787, tt.env, tt.defaultCfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveDaemonAddr() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if bind != tt.wantBind || port != tt.wantPort || source != tt.wantSource {
+				t.Fatalf("resolveDaemonAddr() = (%q, %d, %q), want (%q, %d, %q)", bind, port, source, tt.wantBind, tt.wantPort, tt.wantSource)
+			}
+		})
+	}
+}
+
 func TestInternalCallbackAddrNormalizesWildcardBinds(t *testing.T) {
 	tests := []struct {
 		name string

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,8 +40,10 @@ podiomd
 | `--help` | Show help. |
 | `--version` | Print version and commit. |
 
-Bind address and port come from `config.yaml` (`server.bind`, `server.port`;
-default `127.0.0.1:8787`).
+Bind address and port come from `PODIOM_ADDR` when set, otherwise from
+`config.yaml` (`server.bind`, `server.port`; default `127.0.0.1:8787`). The
+daemon logs `source=env`, `source=config`, or `source=default` with its resolved
+listen address.
 
 ## `podiom`
 
@@ -49,7 +51,7 @@ Global flags:
 
 | Flag | Description |
 | --- | --- |
-| `--addr host:port` | Daemon address. Precedence: `--addr` → `PODIOM_ADDR` → `config.yaml` → `127.0.0.1:8787`. |
+| `--addr host:port` | Daemon address. Precedence: `--addr` → `PODIOM_ADDR` (shared by CLI and daemon) → `config.yaml` → `127.0.0.1:8787`. |
 | `--version` | Print version and commit. |
 
 ### Install scripts


### PR DESCRIPTION
## What changed

`podiomd` now applies `PODIOM_ADDR` before its loaded server config, validates the host and port, and uses the resolved address consistently for its listener and internal callbacks. Startup logs identify whether the address came from the environment, config, or a newly scaffolded default.

## Why

The CLI already honored this variable, while the daemon ignored it. Setting it moved the client alone and made a healthy daemon appear unavailable.

## Validation

- red-first daemon address tests failed because no shared resolver existed
- `go test ./...`
- `go vet ./...`
- focused daemon package tests after the final source-label update
- clean `gofmt` and `git diff --check`

Closes #98
