### PR TITLE
fix(store): acquire write locks before reads

### DIFF
--- a/docs/requirements/foundation.md
+++ b/docs/requirements/foundation.md
@@ -899,7 +899,9 @@ server:
   history after a crash) and for fast queries powering the session list (incl.
   filtering by origin or schedule). Agent **workspaces** remain plain files on
   disk (§5.2), so project content stays transparent and git-friendly; only
-  Podiom's internal bookkeeping lives in the DB.
+  Podiom's internal bookkeeping lives in the DB. Transactions acquire SQLite's
+  write lock before taking a read snapshot, so concurrent read-then-write
+  operations wait for one another instead of failing during lock upgrade.
 - **R11.3** *(O5 — resolved: no limit in v1.)* Podiom imposes **no concurrency
   cap** in v1: every triggered run (interactive or scheduled) executes
   immediately. Accepted trade-off: many parallel Claude turns (each its own

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,9 +23,11 @@ type Store struct {
 // registers under the name "sqlite".
 func Open(path string) (*Store, error) {
 	// Busy timeout avoids spurious "database is locked" errors under the parallel
-	// runs Podiom allows (no concurrency cap, R11.3); foreign_keys + WAL give us
-	// referential integrity and better read/write concurrency.
-	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)", path)
+	// runs Podiom allows (no concurrency cap, R11.3). Immediate transactions take
+	// the write lock before any read snapshot, so read-then-write operations wait
+	// here instead of failing later with SQLITE_BUSY_SNAPSHOT. Foreign keys + WAL
+	// give us referential integrity and better read/write concurrency.
+	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)&_txlock=immediate", path)
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite %s: %w", path, err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,8 +1,10 @@
 package store
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestOpenRunsMigrationsAndIsIdempotent(t *testing.T) {
@@ -29,4 +31,48 @@ func TestOpenRunsMigrationsAndIsIdempotent(t *testing.T) {
 		t.Fatalf("reopen: %v", err)
 	}
 	defer s2.Close()
+}
+
+func TestTransactionsAcquireWriteLockBeforeReads(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "podiom.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if _, err := s.DB().Exec(`CREATE TABLE lock_probe (id INTEGER PRIMARY KEY, value INTEGER);
+		INSERT INTO lock_probe (id, value) VALUES (1, 0)`); err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := s.DB().BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	var value int
+	if err := tx.QueryRow(`SELECT value FROM lock_probe WHERE id = 1`).Scan(&value); err != nil {
+		t.Fatal(err)
+	}
+
+	competingWrite := make(chan error, 1)
+	go func() {
+		_, err := s.DB().Exec(`UPDATE lock_probe SET value = 2 WHERE id = 1`)
+		competingWrite <- err
+	}()
+
+	select {
+	case err := <-competingWrite:
+		t.Fatalf("competing writer bypassed an active transaction: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if _, err := tx.Exec(`UPDATE lock_probe SET value = 1 WHERE id = 1`); err != nil {
+		t.Fatalf("upgrade transaction to writer: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-competingWrite; err != nil {
+		t.Fatalf("competing writer after commit: %v", err)
+	}
 }


### PR DESCRIPTION
## What changed

SQLite transactions now begin with an immediate write lock. Read-then-write operations such as goal-memory commits wait at transaction start instead of taking a stale read snapshot and failing during lock upgrade.

A concurrent database regression holds one transaction after a read, starts a competing writer, and proves that writer waits until the first transaction commits.

## Validation

- red-first regression showed the competing writer bypassing the active deferred transaction
- focused lock test passed five consecutive runs
- `go test ./...`
- `go vet ./...`
- clean `gofmt` and `git diff --check`

Closes #154
