### PR TITLE
test(web): pin the remote-helper guard in remoteError

### DIFF
--- a/web/src/lib/gitremote.test.ts
+++ b/web/src/lib/gitremote.test.ts
@@ -38,6 +38,16 @@ describe("remoteError", () => {
     expect(remoteError(remote)).not.toBe("");
   });
 
+  // A remote helper need not contain whitespace, so this case can only be
+  // rejected by the "::" guard. The shared table above cannot pin that branch:
+  // "ext::sh -c 'id'" also trips the unsafe-character check, so it still
+  // rejects if the "::" guard is deleted.
+  it("rejects a git remote helper with no whitespace", () => {
+    const error = remoteError("ext::sh");
+    expect(error).not.toBe("");
+    expect(error).toContain("remote helper");
+  });
+
   // TrimSpace on the Go side strips a trailing newline, so this must be accepted on both
   // sides. Only an embedded control character is a real problem.
   it("accepts a remote with trailing whitespace, as the server does", () => {


### PR DESCRIPTION
Closes #160

## What

Adds a case to `web/src/lib/gitremote.test.ts` that exercises the `::` (git remote helper) rejection branch specifically: `ext::sh` contains no whitespace, so only the remote-helper guard can reject it. The assertion checks the message contains `remote helper`, so the two guards can't be confused.

## Why

The existing `it.each` case `"ext::sh -c 'id'"` contains spaces, so the unsafe-character guard also rejects it — deleting the `::` branch left the suite green. Verified by mutation: with the `::` branch deleted, the existing case still passed while the new test fails with `expected '' not to be ''` (the value falls through to scp-like parsing and is accepted).

## Testing

- `npm test -w web` — 171 tests pass (gitremote.test.ts 18 → 19)
- `npm run check -w web` — clean
- Mutation check performed as described in the issue: deleting the `::` guard makes the new test fail; source file restored byte-identical.

Note: the same latent gap exists on the Go side (`internal/git/git_test.go` has the identical `"ext::sh -c 'id'"` case) — happy to add the analogous case there as a follow-up if wanted.