### PR TITLE
test(web): pin git remote-helper guard in remoteError

### DIFF
--- a/web/src/lib/gitremote.test.ts
+++ b/web/src/lib/gitremote.test.ts
@@ -28,6 +28,7 @@ describe("remoteError", () => {
     "--upload-pack=touch /tmp/pwned",
     "-oProxyCommand=x",
     "ext::sh -c 'id'",
+    "ext::sh",
     "ssh://-oProxyCommand=x/y",
     "ftp://host/repo.git",
     "git@host:",
@@ -36,6 +37,15 @@ describe("remoteError", () => {
     "git@host:owner\nrepo",
   ])("rejects %j", (remote) => {
     expect(remoteError(remote)).not.toBe("");
+  });
+
+  // Pins the remote-helper guard specifically (issue #160): an ext:: remote without whitespace
+  // would otherwise bypass the UNSAFE guard. Asserting on the message verifies that the
+  // remote-helper branch specifically fired.
+  it("rejects git remote helpers with a dedicated error message", () => {
+    const err = remoteError("ext::sh");
+    expect(err).not.toBe("");
+    expect(err).toContain("remote helper");
   });
 
   // TrimSpace on the Go side strips a trailing newline, so this must be accepted on both


### PR DESCRIPTION
Closes #160.

## Summary

The existing test case `"ext::sh -c 'id'"` contained whitespace, which meant the `UNSAFE` character check was rejecting it before the `value.includes("::")` remote-helper branch could be tested. If the `::` branch was removed, the suite still passed because `ext::sh` with no whitespace was accepted (`""`).

## Changes

- Added `"ext::sh"` (without whitespace) to the `it.each` rejection list.
- Added a dedicated test asserting that the error message specifically contains `"remote helper"` to verify that the remote-helper guard fired rather than a fallback check.

## Verification

- Ran `npm test -w web` (all 172 tests passed).
- Confirmed test failure by temporarily commenting out the `value.includes("::")` guard in `web/src/lib/gitremote.ts` (both new assertions failed as expected).
- Restored the guard and confirmed all tests pass.